### PR TITLE
Use newer version of hugo to match version available on homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 
 install:
   - sudo apt-get install make curl jq
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_extended_0.55.6_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.64.1/hugo_extended_0.64.1_Linux-64bit.deb
   - sudo dpkg -i hugo*.deb
 
 script:


### PR DESCRIPTION
On the branch for https://github.com/buildpacks/docs/compare/anchor-builder-config?expand=1
without this change you see:
<img width="1325" alt="Screen Shot 2020-02-11 at 5 00 11 PM" src="https://user-images.githubusercontent.com/5925347/74283712-5c24d080-4cf0-11ea-8606-ec078b6bb194.png">

with this change you see:
<img width="1006" alt="Screen Shot 2020-02-11 at 5 06 29 PM" src="https://user-images.githubusercontent.com/5925347/74283970-e2d9ad80-4cf0-11ea-8bad-e464b8063728.png">


 - Resolves #105

Signed-off-by: Zander Mackie <zmackie@gmail.com>