### PR TITLE
Fix download buttons and getting started sub-menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ theme = "buildpacks"
 pygmentsUseClasses = true
 pygmentsCodefences = true
 
+[markup.goldmark.renderer]
+unsafe= true
+
 [params]
 twitter_handle = "buildpacks_io"
 github_base_url = "https://github.com/buildpacks"

--- a/content/docs/app-developer-guide/_index.md
+++ b/content/docs/app-developer-guide/_index.md
@@ -9,8 +9,7 @@ expand=true
 
 A lot of the examples used within this guide will require the following: 
 
-<a href="https://store.docker.com/search?type=edition&offering=community" target="_blank" class="download-button button icon-button bg-blue">Install Docker</a>
-
-<a href="/docs/install-pack" class="download-button button icon-button bg-pink">Install Pack</a>
+{{< download-button href="https://store.docker.com/search?type=edition&offering=community" color="blue" >}} Install Docker {{</>}}
+{{< download-button href="/docs/install-pack" color="pink" >}} Install pack {{</>}}
 
 <hr />

--- a/content/docs/app-journey.md
+++ b/content/docs/app-journey.md
@@ -1,6 +1,7 @@
 +++
 title="An App's Brief Journey from Source to Image"
 weight=2
+getting-started=true
 +++
 
 ## `pack` for the journey
@@ -8,8 +9,8 @@ weight=2
 In this tutorial, we'll explain how to use `pack` and **buildpacks** to create a runnable app image from source code.
 
 That means you'll need to make sure you have `pack` installed:
-<br/><br/>
-<a href="/docs/install-pack" class="download-button button icon-button bg-pink">Install pack</a><br/>
+
+{{< download-button href="/docs/install-pack" color="pink" >}} Install pack {{</>}}
 
 > **NOTE:** `pack` is only one implementation of the [Cloud Native Buildpacks Platform Specification][cnb-platform-spec].
 

--- a/content/docs/buildpack-author-guide/create-buildpack/_index.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/_index.md
@@ -8,9 +8,8 @@ summary="This is a step-by-step tutorial for creating a Cloud Native Buildpack u
 
 Before we get started, make sure you've got the following installed: 
 
-<a href="https://store.docker.com/search?type=edition&offering=community" target="_blank" class="download-button button icon-button bg-blue">Install Docker</a>
-
-<a href="/docs/install-pack" class="download-button button icon-button bg-pink">Install Pack</a>
+{{< download-button href="https://store.docker.com/search?type=edition&offering=community" color="blue" >}} Install Docker {{</>}}
+{{< download-button href="/docs/install-pack" color="pink" >}} Install pack {{</>}}
 
 ## Overview
 

--- a/content/docs/install-pack.md
+++ b/content/docs/install-pack.md
@@ -1,16 +1,11 @@
 +++
 title="Installing `pack`"
 weight=1
-creatordisplayname="Andrew Meyer"
-creatoremail="ameyer@pivotal.io"
-lastmodifierdisplayname="Andrew Meyer"
-lastmodifieremail="ameyer@pivotal.io"
-
+getting-started=true
 +++
 
 ## Prerequisites
-<a href="https://store.docker.com/search?type=edition&offering=community" target="_blank" class="download-button button icon-button bg-blue">Install Docker</a>
-
+{{< download-button href="https://store.docker.com/search?type=edition&offering=community" color="blue" >}} Install Docker {{</>}}
 
 ## Supported operating systems
 You can install the most recent version of `pack` (version **{{< latest >}}**) as an executable binary on the following operating systems:

--- a/themes/buildpacks/layouts/partials/sidebar.html
+++ b/themes/buildpacks/layouts/partials/sidebar.html
@@ -7,8 +7,8 @@
       <li data-nav-id="{{.URL}}" class="dd-item depth-0">
         <a href="{{ .RelPermalink }}">{{ .Title }}</a>
         <ul class="ml-2">
-          {{- $pages := .Pages -}}
-          {{- range .Pages.ByWeight }}
+          {{- $pages := where .Pages ".Params.getting-started" true -}}
+          {{- range $pages.ByWeight }}
             {{- if (not .Params.hidden) }}
               {{ $expand := (or (eq $currentNode $home) (in $pages $currentNode))}}
               {{- template "section-tree-nav" dict "currentSection" . "currentNode" $currentNode "depth" 1 "expand" $expand }}

--- a/themes/buildpacks/layouts/shortcodes/download-button.html
+++ b/themes/buildpacks/layouts/shortcodes/download-button.html
@@ -1,0 +1,1 @@
+<a href='{{- .Get "href" -}}' class='download-button button icon-button {{ with .Get "color"}}bg-{{.}}{{ end }}'>{{- .Inner -}}</a><br />

--- a/themes/buildpacks/layouts/shortcodes/summary.html
+++ b/themes/buildpacks/layouts/shortcodes/summary.html
@@ -1,2 +1,3 @@
 {{ $page := .Get 0 }}
+{{ $page := .Get 0 }}
 {{ with .Site.GetPage $page }}{{ .Summary }}{{ end }}


### PR DESCRIPTION
The [update to Hugo broke a few HTML features](https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032) we were using along with the Getting Started menu now iterating and displaying all pages instead of direct children.

This PR addresses these issues via:

1. Moving towards the use of shortcodes for things like consistent buttons.
2. Enabling html (marked as `unsafe`) in the new markdown engine as an immediate fix for other HTML embedded features.
3. Adding a property to top-level "getting-started" pages.


#### Before
![image](https://user-images.githubusercontent.com/475559/74766727-3f861c80-524b-11ea-92d5-9f377755ebf2.png)
![image](https://user-images.githubusercontent.com/475559/74766761-4dd43880-524b-11ea-9bc2-10fa7ab6eb4a.png)

#### After
![image](https://user-images.githubusercontent.com/475559/74766886-7a885000-524b-11ea-953c-28d813b44de4.png)
![image](https://user-images.githubusercontent.com/475559/74766837-65132600-524b-11ea-9b3d-fc98621bffa7.png)
