### PR TITLE
Make environment variable app runnable

### DIFF
--- a/content/docs/app-developer-guide/environment-variables.md
+++ b/content/docs/app-developer-guide/environment-variables.md
@@ -32,7 +32,11 @@ pack build sample-app \
     --env "FOO" \
     --builder cnbs/sample-builder:bionic \
     --buildpack  samples/buildpacks/hello-world/ \
-    --path  samples/apps/java-maven/
+    --buildpack samples/apps/bash-script/bash-script-buildpack/ \
+    --path  samples/apps/bash-script/
+
+# run the app
+docker run sample-app
 ```
 
 The following environment variables were set and available to buildpacks at build-time:
@@ -69,7 +73,11 @@ pack build sample-app \
     --env-file ./envfile \
     --builder cnbs/sample-builder:bionic \
     --buildpack  samples/buildpacks/hello-world/ \
-    --path  samples/apps/java-maven/
+    --buildpack samples/apps/bash-script/bash-script-buildpack/ \
+    --path  samples/apps/bash-script/
+
+# run the app
+docker run sample-app
 ```
 
 The following environment variables were set and available to buildpacks at build-time:


### PR DESCRIPTION
* By using the [bash-script](https://github.com/buildpacks/samples/tree/master/apps/bash-script) sample application, users can simply run the application afterwards, with minimal logging interfering with the hello-world buildpack logs

Fixes #130 

Signed-off-by: David Freilich <dfreilich@vmware.com>