### PR TITLE
App Engine uses Buildpacks now

### DIFF
--- a/themes/buildpacks/layouts/index.html
+++ b/themes/buildpacks/layouts/index.html
@@ -42,7 +42,7 @@
   <h2>About the Project</h2>
   <section class="row">
     <div class="col-sm">
-      <p><strong>Buildpacks</strong> were first conceived by Heroku in 2011. Since then, they have been adopted by Cloud Foundry and other PaaS such as Gitlab, Knative, Deis, Dokku, and Drie.</p>
+      <p><strong>Buildpacks</strong> were first conceived by Heroku in 2011. Since then, they have been adopted by Cloud Foundry and other PaaS such as Gitlab, Knative, Deis, Dokku, Drie and Google App Engine.</p>
 
       <div class="text-center mb-4">
         <img src="/images/history.png" />


### PR DESCRIPTION
App Engine is one of the first PaaS, so I suggest we add it in the list of PaaSes using Buildpacks
Reference: see https://github.com/GoogleCloudPlatform/buildpacks