### PR TITLE
Add Google App Engine as a Buildpack platform

### DIFF
--- a/themes/buildpacks/layouts/index.html
+++ b/themes/buildpacks/layouts/index.html
@@ -42,7 +42,7 @@
   <h2>About the Project</h2>
   <section class="row">
     <div class="col-sm">
-      <p><strong>Buildpacks</strong> were first conceived by Heroku in 2011. Since then, they have been adopted by Cloud Foundry and other PaaS such as Gitlab, Knative, Deis, Dokku, and Drie.</p>
+      <p><strong>Buildpacks</strong> were first conceived by Heroku in 2011. Since then, they have been adopted by Cloud Foundry and other PaaS such as Google App Engine, Gitlab, Knative, Deis, Dokku, and Drie.</p>
 
       <div class="text-center mb-4">
         <img src="/images/history.png" />


### PR DESCRIPTION
Supersedes #174 