### PR TITLE
Add initial non-root requirement documentation

### DIFF
--- a/content/docs/reference/spec/platform-api.md
+++ b/content/docs/reference/spec/platform-api.md
@@ -24,6 +24,9 @@ Buildpacks are stored on the filesystem as unarchived files such that:
 * Each top-level directory is a buildpack ID.
 * Each second-level directory is a buildpack version.
 
+## Users
+For security reasons, images built with platforms, such as `pack`, build and run as non-root users.
+
 ## Further Reading
 
 You can read the complete [Platform API specification on Github](https://github.com/buildpacks/spec/blob/main/platform.md).


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>
Resolves #138 , which should help with https://github.com/spring-projects/spring-boot/issues/21122

I simply added a line (I figured that as a somewhat random requirement in the specification, it would be best to put it in the Platform API documentation). Let me know if it should be expanded upon!

![image](https://user-images.githubusercontent.com/7035673/90532477-497ad080-e145-11ea-8d16-68c7b562b8df.png)
