### PR TITLE
Fix hugo warnings when building

### DIFF
--- a/themes/buildpacks/layouts/partials/header.html
+++ b/themes/buildpacks/layouts/partials/header.html
@@ -6,7 +6,7 @@
     {{ $current := . }}
     {{ range $.Site.Menus.main }}
       {{ $topLevel := replace .URL "/" "" }}
-      <li><a class="{{ if or (eq $current.URL .URL) (eq $current.Type $topLevel) }}active{{end}}" {{if (hasPrefix .URL "https")}}target='_blank'{{end}} href="{{ .URL }}">{{ .Name }}</a></li>
+      <li><a class="{{ if or (eq $current.Permalink .URL) (eq $current.Type $topLevel) }}active{{end}}" {{if (hasPrefix .URL "https")}}target='_blank'{{end}} href="{{ .URL }}">{{ .Name }}</a></li>
     {{ end }}
     <li><a href="https://github.com/buildpacks" class="github-button icon-button bg-blue button">GitHub</a></li>
   </ul>

--- a/themes/buildpacks/layouts/partials/sidebar.html
+++ b/themes/buildpacks/layouts/partials/sidebar.html
@@ -4,7 +4,7 @@
   {{ with .Site.GetPage "/docs" }}
     {{- $home := . -}}
     <ul>
-      <li data-nav-id="{{.URL}}" class="dd-item depth-0">
+      <li data-nav-id="{{.RelPermalink}}" class="dd-item depth-0">
         <a href="{{ .RelPermalink }}">{{ .Title }}</a>
         <ul class="ml-2">
           {{- $pages := where .Pages ".Params.getting-started" true -}}
@@ -33,12 +33,12 @@
   {{- $depth := .depth }}
   {{- with .currentSection}}
     {{- if (not (.Params.hidden))}}
-      {{- $isCurrent := (eq .URL $currentNode.URL) -}}
+      {{- $isCurrent := (eq .RelPermalink $currentNode.RelPermalink) -}}
       {{- $isParent := (and (.IsAncestor $currentNode) (.IsSection)) -}}
       {{- $isCollapsed := (and (gt $depth 0) (not (or $isParent $isCurrent $expand))) }}
       {{- $numberOfPages := (add (len .Pages) (len .Sections)) }}
       {{- safeHTML .Params.head}}
-      <li data-nav-id="{{.URL}}" class="dd-item depth-{{ $depth }}
+      <li data-nav-id="{{.RelPermalink}}" class="dd-item depth-{{ $depth }}
           {{- if $isParent }} parent {{- end }}
           {{- if $isCurrent }} active {{- end }}
           {{- if $isCollapsed }} collapse {{- end }}

--- a/themes/buildpacks/layouts/partials/support.html
+++ b/themes/buildpacks/layouts/partials/support.html
@@ -8,7 +8,7 @@
     {{ if .Params.no_edit }}
     {{ else }}
     {{ $editQuery := (querify "description" "Signed-off-by: NAME <EMAIL_ADDRESS>\n\n> _By signing off you acknowledge adhering to the requirements listed here: https://probot.github.io/apps/dco/_") }}
-    <a href="{{ $.Site.Params.github_base_url }}/docs/edit/main/content/{{ .File.Path }}?{{ $editQuery | safeURL }}"
+    <a href="{{ $.Site.Params.github_base_url }}/docs/edit/main/content/{{ with .File }}{{ .Path }}{{ end }}?{{ $editQuery | safeURL }}"
        class="btn-light btn-small icon-button github-button bg-white inline-flex" target="_blank">Edit</a>
     {{ end }}
   {{ end }}


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

There were been warnings when building Hugo. This PR updates the template to use `Page.RelPermalink` in place of `Page.URL`, and protects against a nullpointer when accessing `.File.Path`