### PR TITLE
Add Windows build guide

### DIFF
--- a/content/docs/app-developer-guide/build-a-windows-app.md
+++ b/content/docs/app-developer-guide/build-a-windows-app.md
@@ -1,0 +1,87 @@
++++
+title="Build a Windows app"
+weight=2
+summary="The basics of taking your Windows app from source code to runnable image."
+aliases=[
+    "/docs/using-pack/building-windows-app/"
+]
++++
+
+> **EXPERIMENTAL:**
+>
+> - Please note that **Windows container support is currently experimental**. You may be asked to enable experimental features  in `pack` when running the following commands. Simply follow the on-screen instructions to do so.
+> - If you encounter any problems while experimenting, we'd love for you to let us know by filing an issue on the [pack][pack-issues] or [lifecycle][lifecycle-issues] repo.
+
+### Recommended reading
+
+Before trying out builds for Windows images, we recommend following the [Linux image tutorial][app-journey] under [Getting Started][getting-started]. Don't worry, you can still run it on a Windows OS if you need to -- just make sure to [enable Linux containers][container-mode] for Docker first.
+
+When you're done, head back here.
+
+### Understanding Docker hosts
+
+The `pack` CLI supports using the [`DOCKER_HOST`][docker-env-vars] environment variable. Essentially, this points your local Docker client (e.g. `docker` or `pack` CLI) to a remote Docker daemon. For instance, if the IP address of your host is `192.168.2.100`, you can set `DOCKER_HOST` to `tcp://192.168.2.100`. Any subsequent `pack` or `docker` commands would communicate with the daemon on that machine instead of a local daemon.
+
+By setting `DOCKER_HOST`, you can use `pack` on any OS to build Windows container images, as long as your remote Docker host is configured to support them (i.e. the host runs a Windows OS and has [Windows container mode enabled][container-mode]).
+
+> **NOTE**: When setting `DOCKER_HOST`, keep in mind that:
+>
+> - any volumes mounted via `pack build --volume <volume> ...` or `docker run --volume <volume> ...` must exist on the _docker host_, not the client machine.
+> - any ports published via `docker run --publish <host-port>:<container-port> ...` will be published on the _docker host_, not the client machine.
+
+### Enable Windows container mode
+
+In order to produce Windows container images, ensure [Windows container mode][container-mode] is enabled in your Docker settings (available only in Docker for Windows). See [Understanding Docker hosts][docker-hosts]) above if you're using a remote Docker host.
+
+Then, building a Windows app using Cloud Native Buildpacks is nearly identical to [building for Linux][build-linux]:
+
+### 1. Select a builder
+
+To [build][build] an app you must first decide which [builder][builder] you're going to use. A builder
+includes the [buildpacks][buildpack] that will be used as well as the environment for building your
+app.
+
+For this guide we're going to use a sample builder, `cnbs/sample-builder:dotnet-framework-1809`.
+
+### 2. Build your app
+
+Now we can build our app. For this example we'll use our [samples][samples] repo for simplicity.
+
+```bash
+# clone the repo
+git clone https://github.com/buildpacks/samples
+
+# build the app
+pack build sample-app --path samples/apps/aspnet --builder cnbs/sample-builder:dotnet-framework-1809 --trust-builder
+```
+
+> **TIP:** If you don't want to keep specifying a builder every time you build, you can set it as your default
+> builder by running `pack set-default-builder <BUILDER>`.
+> <br/><br/>
+> **NOTE:** The requirement to trust Windows builders with `--trust-builder` is temporary and will be no longer
+> be required for `pack` version `0.13.2` and later.
+
+### 3. Run it
+
+```bash
+docker run --rm -it -p 8080:80 sample-app
+```
+
+**Congratulations!**
+
+The app should now be running and accessible via [localhost:8080](http://localhost:8080)
+
+> **NOTE:** If [`DOCKER_HOST` is set][docker-hosts], visit `<docker-host-ip>:8080` instead.
+
+[pack-issues]: https://github.com/buildpacks/pack/issues
+[lifecycle-issues]: https://github.com/buildpacks/lifecycle/issues
+[app-journey]: /docs/app-journey
+[getting-started]: /docs
+[container-mode]: https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers
+[docker-env-vars]: https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+[docker-hosts]: #understanding-docker-hosts
+[build-linux]: /docs/app-developer-guide/build-an-app
+[build]: /docs/concepts/operations/build
+[builder]: /docs/concepts/components/builder
+[buildpack]: /docs/concepts/components/buildpack
+[samples]: https://github.com/buildpacks/samples

--- a/content/docs/app-developer-guide/build-a-windows-app.md
+++ b/content/docs/app-developer-guide/build-a-windows-app.md
@@ -2,9 +2,6 @@
 title="Build a Windows app"
 weight=2
 summary="The basics of taking your Windows app from source code to runnable image."
-aliases=[
-    "/docs/using-pack/building-windows-app/"
-]
 +++
 
 > **EXPERIMENTAL:**
@@ -31,7 +28,7 @@ By setting `DOCKER_HOST`, you can use `pack` on any OS to build Windows containe
 
 ### Enable Windows container mode
 
-In order to produce Windows container images, ensure [Windows container mode][container-mode] is enabled in your Docker settings (available only in Docker for Windows). See [Understanding Docker hosts][docker-hosts]) above if you're using a remote Docker host.
+In order to produce Windows container images, ensure [Windows container mode][container-mode] is enabled in your Docker settings (available only in Docker for Windows). See [Understanding Docker hosts][docker-hosts] above if you're using a remote Docker host.
 
 Then, building a Windows app using Cloud Native Buildpacks is nearly identical to [building for Linux][build-linux]:
 
@@ -57,9 +54,6 @@ pack build sample-app --path samples/apps/aspnet --builder cnbs/sample-builder:d
 
 > **TIP:** If you don't want to keep specifying a builder every time you build, you can set it as your default
 > builder by running `pack set-default-builder <BUILDER>`.
-> <br/><br/>
-> **NOTE:** The requirement to trust Windows builders with `--trust-builder` is temporary and will be no longer
-> be required for `pack` version `0.13.2` and later.
 
 ### 3. Run it
 

--- a/content/docs/app-developer-guide/build-an-app.md
+++ b/content/docs/app-developer-guide/build-an-app.md
@@ -16,8 +16,8 @@ Building an app using Cloud Native Buildpacks is as easy as `1`, `2`, `3`...
 
 ### 1. Select a builder
 
-To [build][build] an app you must first decide what [builder][builder] you are going to use. A builder
-includes the [buildpacks][buildpack] that will be used as well as the environment for building and running your
+To [build][build] an app you must first decide which [builder][builder] you're going to use. A builder
+includes the [buildpacks][buildpack] that will be used as well as the environment for building your
 app.
 
 When using `pack`, you can run `pack suggest-builders` for a list of suggested builders.
@@ -26,12 +26,12 @@ When using `pack`, you can run `pack suggest-builders` for a list of suggested b
 pack suggest-builders
 ```
 
-For this tutorial we're actually going to use a sample builder, `cnbs/sample-builder:bionic`, which is not listed
+For this guide we're actually going to use a sample builder, `cnbs/sample-builder:bionic`, which is not listed
 as a suggested builder for good reason. It's a sample.
 
 ### 2. Build your app
 
-Now that you've decided on what builder to use, we can build our app. For this example we will use our [samples][samples]
+Now that you've decided on what builder to use, we can build our app. For this example we'll use our [samples][samples]
 repo for simplicity.
 
 ```bash
@@ -39,10 +39,10 @@ repo for simplicity.
 git clone https://github.com/buildpacks/samples
 
 # build the app
-pack build sample-app --path samples/apps/java-maven/ --builder cnbs/sample-builder:bionic
+pack build sample-app --path samples/apps/java-maven --builder cnbs/sample-builder:bionic
 ```
 
-> **Tip:** If you didn't want to keep specifying a builder every time you build, you could set it as your default
+> **TIP:** If you don't want to keep specifying a builder every time you build, you can set it as your default
 > builder by running `pack set-default-builder <BUILDER>`.
 
 ### 3. Run it
@@ -54,6 +54,12 @@ docker run --rm -p 8080:8080 sample-app
 **Congratulations!**
 
 The app should now be running and accessible via [localhost:8080](http://localhost:8080).
+
+## What about Windows apps?
+
+Windows image builds are now supported!
+
+<a href="/docs/app-developer-guide/build-a-windows-app" class="button bg-blue">Windows build guide</a>
 
 [build]: /docs/concepts/operations/build
 [builder]: /docs/concepts/components/builder

--- a/content/docs/app-developer-guide/environment-variables.md
+++ b/content/docs/app-developer-guide/environment-variables.md
@@ -1,6 +1,6 @@
 +++
 title="Environment variables"
-weight=1
+weight=3
 summary="Environment variables are a common way to configure various buildpacks at build-time."
 +++
 

--- a/content/docs/app-developer-guide/run-an-app.md
+++ b/content/docs/app-developer-guide/run-an-app.md
@@ -1,6 +1,6 @@
 +++
 title="Specify launch process"
-weight=1
+weight=5
 summary="Learn how to specify the launch process for an app."
 +++
 

--- a/content/docs/app-developer-guide/specific-buildpacks.md
+++ b/content/docs/app-developer-guide/specific-buildpacks.md
@@ -1,6 +1,6 @@
 +++
 title="Specify buildpacks"
-weight=1
+weight=4
 summary="Learn how to specify exactly what buildpacks are used during the build process."
 +++
 

--- a/content/docs/app-developer-guide/using-project-descriptor.md
+++ b/content/docs/app-developer-guide/using-project-descriptor.md
@@ -1,6 +1,6 @@
 +++
 title="Using project.toml"
-weight=3
+weight=6
 summary="Learn how to use a project.toml file to simplify configuring pack."
 +++
 

--- a/content/docs/app-journey.md
+++ b/content/docs/app-journey.md
@@ -74,16 +74,21 @@ To test out your new app image locally, you can run it with Docker:
 docker run --rm -p 8080:8080 myapp
 ```
 
-Now hit `localhost:8080` in your favorite browser and take a minute to enjoy the view.
+Now hit [`localhost:8080`](http://localhost:8080) in your favorite browser and take a minute to enjoy the view.
 
 ### Take your image to the skies
 
 `pack` uses **buildpacks** to help you easily create OCI images that you can run just about anywhere. Try
 deploying your new image to your favorite cloud!
 
-> In case you need it, `pack build` has a handy flag called `--publish` that will publish your app image to a Docker
-> registry after building it.
+> In case you need it, `pack build` has a handy flag called `--publish` that will build your image directly onto a Docker
+> registry.
 
+## What about Windows apps?
+
+Windows image builds are now supported!
+
+<a href="/docs/app-developer-guide/build-a-windows-app" class="button bg-blue">Windows build guide</a>
 
 [builder]: /docs/concepts/components/builder/
 [buildpack]: /docs/concepts/components/buildpack/

--- a/content/docs/buildpack-author-guide/package-a-buildpack.md
+++ b/content/docs/buildpack-author-guide/package-a-buildpack.md
@@ -62,7 +62,7 @@ Lastly, we'll run the `package-buildpack` command to package the buildpack as an
 pack package-buildpack my-buildpack --config ./package.toml
 ```
 
-> **Tip:** You can verify that the image was created by running `docker images`.
+> **TIP:** You can verify that the image was created by running `docker images`.
 
 That's it! Your buildpack is now packaged for distribution.
 

--- a/content/docs/concepts/operations/rebase.md
+++ b/content/docs/concepts/operations/rebase.md
@@ -27,7 +27,7 @@ run image called `pack/run`. Running the following will update the base of `my-a
 $ pack rebase my-app:my-tag
 ```
 
-> **Tip:** `pack rebase` has a `--publish` flag that can be used to publish the updated app image directly to a registry. 
+> **TIP:** `pack rebase` has a `--publish` flag that can be used to publish the updated app image directly to a registry. 
 > Using `--publish` is optimal when using a registry in comparison to the docker daemon.
 
 [build]: /docs/app-developer-guide/build-an-app/

--- a/content/docs/operator-guide/create-a-builder.md
+++ b/content/docs/operator-guide/create-a-builder.md
@@ -67,7 +67,7 @@ Creating a builder is now as simple as running the following command:
 pack create-builder my-builder:bionic --config ./builder.toml
 ```
 
-> **Tip:** `create-builder` has a `--publish` flag that can be used to publish the generated builder image to a registry.
+> **TIP:** `create-builder` has a `--publish` flag that can be used to publish the generated builder image to a registry.
 
 **Congratulations!** You've got a custom builder.
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpacks/docs/tools
 go 1.14
 
 require (
-	github.com/buildpacks/pack v0.13.0
+	github.com/buildpacks/pack v0.13.1
 	github.com/dgodd/dockerdial v1.0.1 // indirect
 	github.com/gobuffalo/envy v1.9.0 // indirect
 	github.com/gohugoio/hugo v0.74.3

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -134,6 +134,8 @@ github.com/buildpacks/pack v0.12.0 h1:S2qFQNx+Tk8ZfmM+aonC9Zu5WaPuUOq8kwz76+84pR
 github.com/buildpacks/pack v0.12.0/go.mod h1:lW6nn3FXzR8NHH12RlOILXf++qGk5BbaclEqwY+rflg=
 github.com/buildpacks/pack v0.13.0 h1:Wc+Ph1UQcizKGTxcK/QfjBW1kxTJxhFRSw8asmI25lM=
 github.com/buildpacks/pack v0.13.0/go.mod h1:P7Hj8ltMWZ/Yt++ZbvAU/Zr8C7iTZT0L5pO5H7dfRKY=
+github.com/buildpacks/pack v0.13.1 h1:x5nbIurGTo8GYexorNxp+YThbU4TsrGbNZLzjZvepo0=
+github.com/buildpacks/pack v0.13.1/go.mod h1:P7Hj8ltMWZ/Yt++ZbvAU/Zr8C7iTZT0L5pO5H7dfRKY=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
- Adds a Windows-centric guide to the App Developer Guides
- References new guide from the main App Journey tutorial, and from the Linux build guide

Signed-off-by: Andrew Meyer <meyeran@vmware.com>