### PR TITLE
Add option to install pack CLI using scoop on Windows

### DIFF
--- a/content/docs/tools/pack/cli/install.md
+++ b/content/docs/tools/pack/cli/install.md
@@ -56,9 +56,13 @@ brew install buildpacks/tap/pack
 ---
 
 ## Windows
-To install `pack` on Windows, we recommend using Chocolatey:
+To install `pack` on Windows, we recommend using [Chocolatey](https://chocolatey.org/):
 ```
 choco install pack --version={{< latest >}}
+```
+or [scoop](https://scoop.sh/):
+```
+scoop install pack
 ```
 
 Alternatively, you can install the Windows executable for `pack` by downloading the Windows [ZIP file](https://github.com/buildpacks/pack/releases/download/v{{< latest >}}/pack-v{{< latest >}}-windows.zip).


### PR DESCRIPTION
Additional option to install pack CLI (using scoop) on Windows has been documented.
The new way of installation is possible due to ScoopInstaller/Main#1402.

Scoop's packages database is refreshed once a day so it will always install the latest version available.

Signed-off-by: Marcin Kłopotek <marcin.klopotek@gmail.com>