### PR TITLE
Ignore output checks

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/build-app.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/build-app.md
@@ -51,7 +51,6 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 you will see the following output:
 
-<!-- test:assert=contains;ignore-lines=... -->
 ```
 ===> DETECTING
 ...

--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -101,7 +101,6 @@ The `pack build` command takes in your Ruby sample app as the `--path` argument 
 
 After running the command, you should see that it failed to detect, as the `detect` script is currently written to simply error out.
 
-<!-- test:assert=contains -->
 ```
 ===> DETECTING
 [detector] err:  com.examples.buildpacks.ruby@0.0.1 (1)

--- a/content/docs/buildpack-author-guide/create-buildpack/caching.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/caching.md
@@ -236,7 +236,6 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 it will download the gems:
 
-<!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
 [builder] ---> Ruby Buildpack
@@ -255,7 +254,6 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 you will see the new caching logic at work during the `BUILDING` phase:
 
-<!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
 [builder] ---> Ruby Buildpack

--- a/content/docs/buildpack-author-guide/create-buildpack/detection.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/detection.md
@@ -36,7 +36,6 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 You should see the following output:
 
-<!-- test:assert=contains -->
 ```
 ===> DETECTING
 [detector] com.examples.buildpacks.ruby 0.0.1

--- a/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
@@ -120,7 +120,6 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 You will notice that version of Ruby specified in the app's `.ruby-version` file is downloaded.
 
-<!-- test:assert=contains -->
 ```text
 ===> BUILDING
 [builder] ---> Ruby Buildpack


### PR DESCRIPTION
This change makes it so that the output is not checked against as part of the tests due to https://github.com/buildpacks/pack/issues/860.