### PR TITLE
Fix typo in example mixin label name

### DIFF
--- a/content/docs/concepts/components/stack.md
+++ b/content/docs/concepts/components/stack.md
@@ -116,12 +116,12 @@ The following rules apply for mixin declarations:
 
 _Build image:_
 ```json
-io.buildpack.stack.mixins: ["build:git", "wget"]
+io.buildpacks.stack.mixins: ["build:git", "wget"]
 ```
 
 _Run image:_
 ```json
-io.buildpack.stack.mixins: ["run:imagemagick", "wget"]
+io.buildpacks.stack.mixins: ["run:imagemagick", "wget"]
 ```
 
 ### Declaring required mixins


### PR DESCRIPTION
Signed-off-by: Javier Romero <rjavier@vmware.com>

Resolves #262