### PR TITLE
Add link to registry in the navbar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,3 +42,9 @@ pack_version_env_var = "PACK_VERSION"
   name       = "Blog"
   url        = "https://medium.com/buildpacks"
   weight     = 4
+
+  [[menu.main]]
+  identifier = "registry"
+  name       = "Registry"
+  url        = "https://registry.buildpacks.io/"
+  weight     = 5


### PR DESCRIPTION
## Changes
- Add a link to the registry in the navbar

![image](https://user-images.githubusercontent.com/34343421/108132718-5c149900-70d9-11eb-8dbb-b7c6b0722a9c.png)

Fixes buildpacks/registry-api#29 