### PR TITLE
Update publishing-with-github-actions.md

### DIFF
--- a/content/docs/buildpack-author-guide/publishing-with-github-actions.md
+++ b/content/docs/buildpack-author-guide/publishing-with-github-actions.md
@@ -42,7 +42,7 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_PASS }}
     - id: setup-pack
-      uses: buildpacks/github-actions/setup-pack@v4.0.0
+      uses: buildpacks/github-actions/setup-pack@v4.1.0
     - id: package
       run: |
         #!/usr/bin/env bash
@@ -59,7 +59,7 @@ jobs:
       env:
         REPO: docker.io/${{ secrets.DOCKER_HUB_USER }}
     - id: register
-      uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
+      uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.1.0
       with:
         token:   ${{ secrets.PUBLIC_REPO_TOKEN }}
         id:      ${{ steps.package.outputs.bp_id }}


### PR DESCRIPTION
Upgrade the setup-pack action version. This ensures that a newer version of Pack CLI is used (0.17.0), which includes some important bug fixes for the registry.