### PR TITLE
Pin workflow (CI) to use go 1.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '1.x'
+          go-version: '1.15.x'
       - name: Install Dependencies
         run: sudo apt-get install make curl jq
       - name: Test


### PR DESCRIPTION
This is a temporary solution to unblock our pipelines but we'd want to figure out how to successfully upgrade to work with go1.16.

Context:
- [Failing build](https://github.com/buildpacks/docs/runs/1973682785?check_suite_focus=true)