### PR TITLE
Add -mod=mod flag to go install for build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: '1.15.x'
+          go-version: '1.x'
       - name: Install Dependencies
         run: sudo apt-get install make curl jq
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 install-hugo:
 	@echo "> Installing hugo..."
-	cd tools; go install --tags extended github.com/gohugoio/hugo
+	cd tools; go install -mod=mod --tags extended github.com/gohugoio/hugo
 
 install-pack-cli:
 	@echo "> Installing pack bin..."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)
 
 # docs
-Website for [Cloud Native Buildpacks](https://buildpacks.io)
+Website for [Cloud Native Buildpacks](https://buildpacks.io) testing
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)
 
 # docs
-Website for [Cloud Native Buildpacks](https://buildpacks.io) testing
+Website for [Cloud Native Buildpacks](https://buildpacks.io)
 
 ## Development
 


### PR DESCRIPTION
Fixes: https://github.com/buildpacks/docs/issues/311

`go install` behavior changed from 1.15 -> 1.16: the command no longer updates go.sum by default when packages are installed, causing the "missing packages" error. (related: https://github.com/golang/go/issues/44212)