### PR TITLE
Remove old Dockerfile reference

### DIFF
--- a/data/pack/install.yml
+++ b/data/pack/install.yml
@@ -9,8 +9,7 @@
     - &container
       name: Container
       content: |
-        `pack` is available as a container image on Docker Hub as [`buildpacksio/pack`](https://hub.docker.com/r/buildpacksio/pack)
-        ([definition files](https://github.com/buildpacks/pack/blob/main/.github/workflows/delivery/docker/Dockerfile)).
+        `pack` is available as a container image on Docker Hub as [`buildpacksio/pack`](https://hub.docker.com/r/buildpacksio/pack).
 
         #### Tags
 


### PR DESCRIPTION
Fixes a broken link to a Dockerfile that no longer exists now that we use buildpacks to build our pack container image.

![image](https://user-images.githubusercontent.com/475559/109179921-00d54d00-7750-11eb-8f2a-de2076f54b40.png)
