### PR TITLE
Fix buildpack ids to contain namespaces in the BP authors guide

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
@@ -27,8 +27,8 @@ Run Images:
   cnbs/sample-stack-run:bionic
 
 Buildpacks:
-  ID                                  VERSION
-  com.examples.buildpacks.ruby        0.0.1
+  ID                   VERSION
+  examples/ruby        0.0.1
 
 Processes:
   TYPE                 SHELL        COMMAND                        ARGS
@@ -160,7 +160,7 @@ You should find that the included `ruby` version is `2.5.0` as expected.
         "version": "2.5.0"
       },
       "buildpacks": {
-        "id": "com.examples.buildpacks.ruby",
+        "id": "examples/ruby",
         "version": "0.0.1"
       }
     }

--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -27,7 +27,7 @@ api = "0.5"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "com.examples.buildpacks.ruby"
+id = "examples/ruby"
 version = "0.0.1"
 name = "Ruby Buildpack"
 
@@ -104,7 +104,7 @@ After running the command, you should see that it failed to detect, as the `dete
 <!-- test:assert=contains -->
 ```
 ===> DETECTING
-[detector] err:  com.examples.buildpacks.ruby@0.0.1 (1)
+[detector] err:  examples/ruby@0.0.1 (1)
 [detector] ERROR: No buildpack groups passed detection.
 [detector] ERROR: failed to detect: buildpack(s) failed with err
 ```

--- a/content/docs/buildpack-author-guide/create-buildpack/caching.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/caching.md
@@ -92,7 +92,7 @@ You will see something similar to the following during the `EXPORTING` phase:
 
 <!-- test:assert=contains -->
 ```text
-[exporter] Adding layer 'com.examples.buildpacks.ruby:bundler'
+[exporter] Adding layer 'examples/ruby:bundler'
 ```
 
 ## Caching dependencies

--- a/content/docs/buildpack-author-guide/create-buildpack/detection.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/detection.md
@@ -39,7 +39,7 @@ You should see the following output:
 <!-- test:assert=contains -->
 ```
 ===> DETECTING
-[detector] com.examples.buildpacks.ruby 0.0.1
+[detector] examples/ruby 0.0.1
 ===> ANALYZING
 [analyzer] Previous image with name "test-ruby-app" not found
 ===> RESTORING


### PR DESCRIPTION
The BP authors guide seems to suggest creating buildpacks with ids that don't have a namespace. This is not compatible with buildpacks that will be published to a registry.