### PR TITLE
Embed talk videos into docs page + add resources (slides)

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -52,26 +52,8 @@ This is a community driven project and our roadmap is publicly available on our 
 
 ---
 
-# Additional Resources
+# Talks
 
-## Helpful Videos
+{{< talks >}}
 
-[Intro to Cloud Native Buildpacks (KubeCon NA 2019)](https://www.youtube.com/watch?v=SK6e_ZatOaw)
-
-  - Terence and Emily discuss how buildpacks work, why the project was created, and give some demos
-
-[Deep Dive: Cloud Native Buildpacks (KubeCon NA 2019)](https://www.youtube.com/watch?v=j9Ak5YLrihU)
-
-  - Stephen and Joe describe why you need a buildpack, how to create one, and what you'll gain from using them
-
-[Pack to the Future: Cloud Native Buildpacks on k8s (Spring One 2019)](https://www.youtube.com/watch?v=J2SXkmOo8iQ)
-
-  - Emily and Joe talk about how to use the Pack CLI
-
-[Buildpacks Can Be Better](https://www.youtube.com/watch?v=J6zn3WRqJko)
-
-  - Stephen and Tyler present at the 2018 Cloud Foundry Summit and discuss the problems posed by poorly structured Dockerfiles, the solution buildpacks offer, and recent innovations in the buildpacks model (including OCI images!)
-
-[The Future of Opinionated Buildpacks](https://www.youtube.com/watch?v=spW9ZlJpobM)
-
-  - Emily and Stephen discuss the advantages of OCI images and give a demo using a basic node app
+---

--- a/data/talks.yml
+++ b/data/talks.yml
@@ -1,0 +1,92 @@
+# - name (required): Name of video
+#   description: Short video description
+#   preseters: Presenters of talk
+#      - Name, Employer
+#   youtube_id (required): URL to video
+#   year: Year recorded
+#   resources: Resources to link to
+#     - name: Name of resource
+#       icon: Icon name (font-awesome 5 - https://fontawesome.com/icons?d=gallery&p=2&m=free)
+#       url: URL to resource
+- name: "Intro: Cloud Native Buildpacks"
+  presenters:
+    - Terence Lee, Heroku
+    - Emily Casey, Pivotal
+  description: >-
+    You're great at running containers but you shouldn't have to be great at building them. In this talk,
+    you'll learn about Cloud Native Buildpacks, a higher-level abstraction for building apps compared to
+    Dockerfiles. Buildpacks are a standardized tool for creating images in a secure, reproducible, and
+    efficient manner. As an app developer, you don't need to know best practices around ordering commands
+    for layer reuse. As an operator, you don't need to worry about exposing developers to the responsibilities
+    that come with Dockerfile. Come learn how buildpacks meet developers at their source code, automate
+    the delivery of both OS-level and application-level dependency upgrades, and help you efficiently handle
+    day-2 app operations.
+  youtube_id: SK6e_ZatOaw
+  year: 2019
+  resources:
+    - name: Slides
+      icon: file-powerpoint
+      url: https://docs.google.com/presentation/d/14cjPH520VGx9aGi4rHRIqgl7RHdUmCRj6PYFEBINPhs/view
+- name: "Deep Dive: Cloud Native Buildpacks"
+  presenters:
+    - Joe Kutner, Heroku
+    - Stephen Levine, Pivotal
+  description: >-
+    Learn why you need a buildpack and how to create one. We'll take advantage of caching and Docker
+    layers to speed up rebuilds and deploys. Unlike Dockerfiles, buildpacks are composable. Finally,
+    you'll learn how to rebase your application layers on a new image. This allow operators to efficiently
+    handle the delivery of OS-level dependency upgrades. 
+  youtube_id: j9Ak5YLrihU
+  resources:
+    - name: Slides
+      icon: file-powerpoint
+      url: https://docs.google.com/presentation/d/14cjPH520VGx9aGi4rHRIqgl7RHdUmCRj6PYFEBINPhs/view
+- name: "Pack to the Future: Cloud-Native Buildpacks on k8s"
+  presenters:
+    - Emily Casey, Pivotal
+    - Joe Kutner, Heroku
+  description: >-
+    Are you a developer that would rather build features than maintain Dockerfiles? Is your organization
+    excited about Kubernetes but worried about patching vulnerable dependencies across a great number of
+    containers? In this talk, you’ll learn how to use the pack CLI to go from source to image in seconds
+    and patch a pod even faster. Cloud Foundry and Heroku users have long appreciated the developer
+    experience and security guarantees provided by buildpacks. Cloud-Native Buildpacks (a CNCF sandbox
+    project) represents a generational leap in buildpacks, bringing the power of buildpacks to k8s and
+    beyond.
+  youtube_id: J2SXkmOo8iQ
+  year: 2019
+  resources:
+    - name: Slides
+      icon: file-powerpoint
+      url: https://docs.google.com/presentation/d/14rkLA2hn3nVu_liiW6Y7hy3hSsnz1HueEdLkhvChONM/view
+- name: "Cloud Native Buildpacks: Containers for Everyone"
+  presenters:
+    - Danielle Adams, Heroku
+  description: >-
+    Buildpacks are the core of Heroku - they lower the operational burden of creating and maintaining
+    application environments. Cloud Native Buildpacks combine Heroku’s seamless developer experience
+    with modern container standards, making it easy to build Docker images from Node.js source code.
+    In this talk, Node developers can learn how to perform both OS and application-level upgrades,
+    create Docker images without Dockerfiles, and run containerized Node.js apps with little
+    configuration. (Docker experience not required.)
+  youtube_id: "-u5FIbi3Gs8"
+  year: 2019
+  resources:
+    - name: Slides
+      icon: file-powerpoint
+      url: https://slides.com/danielleadams/cnbs-node-js-interactive-19
+- name: "Production CI/CD w/CNBs: Tekton, Gitlab & CircleCI(plus), Oh My!"
+  presenters:
+    - David Freilich, VMware
+    - Natalie Arellano, VMware
+  description: >-
+    Dive into some new functionality of Cloud Native Buildpacks which can be powerful in the enterprise
+    context, such as the ability to narrowly define trusted builders, allowing developers and operators
+    to restrict access to registry credentials, as well as the ability to create Windows images in a
+    number of CI/CD systems, including Tekton, Gitlab and CircleCI.
+  youtube_id: RNN8XwRWGjk
+  year: 2020
+  resources: 
+    - name: Slides
+      icon: file-powerpoint
+      url: https://docs.google.com/presentation/d/1vDv33oHU277mh6oCP7vBqQomMpPFIuzSmMTtfaQyBoY/view

--- a/themes/buildpacks/assets/scss/_helpers.scss
+++ b/themes/buildpacks/assets/scss/_helpers.scss
@@ -32,3 +32,7 @@ img {
 .opacity-100 {
   opacity: 1;
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/themes/buildpacks/assets/scss/components/_talks.scss
+++ b/themes/buildpacks/assets/scss/components/_talks.scss
@@ -1,0 +1,19 @@
+/**********************************
+
+Talks Widget
+
+**********************************/
+
+.talks-presenter {
+  font-size: 0.8rem;
+  white-space:nowrap;
+}
+
+.talk {
+  border-left: 6px solid transparent;
+
+  &[data-active="true"] {
+    border-left-color: $pink;
+  }
+}
+

--- a/themes/buildpacks/assets/scss/site.scss
+++ b/themes/buildpacks/assets/scss/site.scss
@@ -22,6 +22,7 @@
 @import 'components/highlights';
 @import "components/quote";
 @import "components/tabs";
+@import "components/talks";
 @import 'components/lists';
 @import 'components/calendar';
 

--- a/themes/buildpacks/layouts/shortcodes/talks.html
+++ b/themes/buildpacks/layouts/shortcodes/talks.html
@@ -11,12 +11,12 @@
       <!-- https://css-tricks.com/aspect-ratio-boxes/#the-core-concept-padding-in-percentages-is-based-on-width -->
       <div style="position: relative; padding-bottom: 109.25%; height: 0; overflow: auto;">
         {{ range $i, $talk := $.Site.Data.talks }}
-        <div data-talk-index="{{$i}}" class="border-bottom pl-3 pr-1 py-1" style="overflow-y: auto;">
-          <div class="talks-name small font-weight-bold">{{ $talk.name }}</div>
-          <div class="talks-name small font-italic">
+        <div data-talk-index="{{$i}}" class="talk border-bottom pl-2 pr-1 py-1 pointer">
+          <div class="small font-weight-bold">{{ $talk.name }}</div>
+          <div class="small font-italic">
             {{ range $i, $presenter := $talk.presenters }}
             {{if ne $i 0}} & {{ end }}
-            <span style="font-size: 0.8rem; white-space:nowrap;">{{$presenter}}</span>
+            <span class="talks-presenter">{{$presenter}}</span>
             {{ end }}
           </div>
         </div>
@@ -46,8 +46,15 @@
     let $talkResources = $("#talk-resources");
 
     $("#talks-playlist div[data-talk-index]").on('click', function () {
-      let index = $(this).attr('data-talk-index');
+      $el = $(this);
+      let index = $el.attr('data-talk-index');
       let talk = talks[index];
+
+      // set active talk in playlist
+      $("#talks-playlist div[data-talk-index]").each(function() {
+        $(this).attr('data-active', 'false');
+      })
+      $(this).attr('data-active', 'true');
 
       // update video player
       let $video_player = $("#talks-player iframe");

--- a/themes/buildpacks/layouts/shortcodes/talks.html
+++ b/themes/buildpacks/layouts/shortcodes/talks.html
@@ -1,0 +1,76 @@
+<div id="talks" class="px-2">
+  <div class="row border">
+    <div id="talks-player" class="col-md-8 px-0">
+      <!-- https://css-tricks.com/aspect-ratio-boxes/#the-core-concept-padding-in-percentages-is-based-on-width -->
+      <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+        <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"
+          allowfullscreen></iframe>
+      </div>
+    </div>
+    <div id="talks-playlist" class="col-md-4 px-0">
+      <!-- https://css-tricks.com/aspect-ratio-boxes/#the-core-concept-padding-in-percentages-is-based-on-width -->
+      <div style="position: relative; padding-bottom: 109.25%; height: 0; overflow: auto;">
+        {{ range $i, $talk := $.Site.Data.talks }}
+        <div data-talk-index="{{$i}}" class="border-bottom pl-3 pr-1 py-1" style="overflow-y: auto;">
+          <div class="talks-name small font-weight-bold">{{ $talk.name }}</div>
+          <div class="talks-name small font-italic">
+            {{ range $i, $presenter := $talk.presenters }}
+            {{if ne $i 0}} & {{ end }}
+            <span style="font-size: 0.8rem; white-space:nowrap;">{{$presenter}}</span>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+  <div class="row p-2">
+    <div>
+      <div class="font-weight-bold">Description</div>
+      <div id="talk-description"></div>
+    </div>
+  </div>
+  <div class="row p-2">
+    <div>
+      <div class="font-weight-bold">Resources</div>
+      <div id="talk-resources"></div>
+    </div>
+  </div>
+</div>
+
+<script type="application/javascript">
+  let talks = {{ $.Site.Data.talks | jsonify | safeJS }};
+
+  $(function () {
+    let $talkDescription = $("#talk-description");
+    let $talkResources = $("#talk-resources");
+
+    $("#talks-playlist div[data-talk-index]").on('click', function () {
+      let index = $(this).attr('data-talk-index');
+      let talk = talks[index];
+
+      // update video player
+      let $video_player = $("#talks-player iframe");
+      let url = "https://www.youtube.com/embed/" + talk.youtube_id + "?autoplay=0&modestbranding=1&rel=0&iv_load_policy=3&controls=1";
+      if (url != $video_player.attr("src")) {
+        $video_player.attr("src", url);
+        $video_player.attr("title", talk.name);
+      }
+
+      // populate description
+      $talkDescription.empty().html(talk.description);
+
+      // populate resources
+      $talkResources.empty();
+      (talk.resources || []).forEach(resource => {
+        $talkResources.append(`
+        <a class="d-inline-block button-light button rounded border p-1" href="${resource.url}" target="_blank">
+          <i class="fas fa-${resource.icon}"></i> ${resource.name}
+        </a>
+        `);
+      });
+    });
+
+    $("#talks-playlist div[data-talk-index]")[0].click();
+  });
+</script>


### PR DESCRIPTION
### Summary

Add a more integrated video talks into our Getting Started page along with "resources". In this initial pass, the resources associated to the talks are slides. I can foresee additional resources such as a git repository or tutorial workbook.

### Preview

![image](https://user-images.githubusercontent.com/475559/110724694-e4b7be00-81db-11eb-824c-91e53d2a381a.png)


Resolves #127 