### PR TITLE
Fix broken link to builder configuration file

### DIFF
--- a/content/docs/concepts/components/stack.md
+++ b/content/docs/concepts/components/stack.md
@@ -21,7 +21,7 @@ stacks that can be used when running `pack builder create`, along with each stac
 ## Using stacks
 
 Stacks are used by [builders][builder] and are configured through a builder's
-[configuration file](/docs/concepts/components/builder#builder-configuration):
+[configuration file](/docs/reference/config/builder-config/):
 
 ```toml
 [[buildpacks]]


### PR DESCRIPTION
Since as of #69, the "Builder Configuration" section no longer exists on:
https://buildpacks.io/docs/concepts/components/builder/

The link now targets the reference section instead:
https://buildpacks.io/docs/reference/config/builder-config/