### PR TITLE
Add Google Analytics and Dashboard

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,3 +43,33 @@ pack_version_env_var = "PACK_VERSION"
   name       = "Registry"
   url        = "https://registry.buildpacks.io/"
   weight     = 4
+
+  [[menu.footer1]]
+  name       = "DevStats"
+  url        = "https://registry.buildpacks.io/"
+  weight     = 1
+
+  [[menu.footer1]]
+  name       = "Analytics"
+  url        = "https://datastudio.google.com/reporting/4b23856c-6c24-44f5-86f2-333d0ad3f236"
+  weight     = 2
+
+  [[menu.footer2]]
+  name       = "Mailing List"
+  url        = "https://lists.cncf.io/g/cncf-buildpacks/join"
+  weight     = 1
+
+  [[menu.footer2]]
+  name       = "Slack"
+  url        = "https://slack.buildpacks.io/"
+  weight     = 2
+
+  [[menu.footer2]]
+  name       = "Twitter"
+  url        = "https://twitter.com/buildpacks_io"
+  weight     = 3
+
+  [[menu.footer2]]
+  name       = "GitHub"
+  url        = "https://github.com/buildpacks"
+  weight     = 4

--- a/themes/buildpacks/layouts/_default/baseof.html
+++ b/themes/buildpacks/layouts/_default/baseof.html
@@ -19,6 +19,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-CJLSR4FQXL"></script>
+
   <script>
     $(function () {
       $('h1[id], h2[id], h3[id], h4[id], h5[id]').not(':has(a)').each(function () {
@@ -37,6 +39,11 @@
         });
       }
     });
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-CJLSR4FQXL');
   </script>
 
   <title>{{ .Title | plainify }} · {{ .Site.Title }}</title>

--- a/themes/buildpacks/layouts/partials/footer.html
+++ b/themes/buildpacks/layouts/partials/footer.html
@@ -5,12 +5,16 @@
   </div>
   <div class="bg-blue">
     <div class="container sub-footer">
-      <p>Reach out <a href="https://slack.buildpacks.io">on Slack</a> to learn more.</p>
       <ul>
-        <li><a href="https://lists.cncf.io/g/cncf-buildpacks/join" target="_blank">Mailing List</a> <span>&bull;</span></li>
-        <li><a href="{{ $.Site.Params.slack_invite_url }}" target="_blank">Slack</a> <span>&bull;</span></li>
-        <li><a href="https://twitter.com/{{ $.Site.Params.twitter_handle }}" target="_blank">Twitter</a> <span>&bull;</span></li>
-        <li><a href="{{ $.Site.Params.github_base_url }}" target="_blank">GitHub</a></li>
+        {{ range $i, $item := $.Site.Menus.footer1 }}
+        <li>{{ if $i }}<span>&bull;</span>{{ end }}<a target='_blank' href="{{ $item.URL }}">{{$item.Name}}</a></li>
+        {{ end }}
+      </ul>
+
+      <ul>
+        {{ range $i, $item := $.Site.Menus.footer2 }}
+        <li>{{ if $i }}<span>&bull;</span>{{ end }}<a target='_blank' href="{{ $item.URL }}">{{$item.Name}}</a></li>
+        {{ end }}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This change adds basic Google Analytics integrations as well as a link to the public [dashboard](https://datastudio.google.com/reporting/4b23856c-6c24-44f5-86f2-333d0ad3f236).

NOTE: Some fields are not populated yet due to the lack of data but should populate after a few days.


### Before
![image](https://user-images.githubusercontent.com/475559/113357072-eec76b00-9308-11eb-93db-39b3c2f8d76c.png)

### After

![image](https://user-images.githubusercontent.com/475559/113357086-fab32d00-9308-11eb-8007-b1996725502f.png)

![image](https://user-images.githubusercontent.com/475559/113357139-19192880-9309-11eb-8ac4-070558c2dbb2.png)

Resolves #346 