### PR TITLE
Polish: Show summaries for lifecycle phases

### DIFF
--- a/content/docs/concepts/_index.md
+++ b/content/docs/concepts/_index.md
@@ -2,5 +2,7 @@
 title="Concepts"
 weight=3
 include_summaries=true
+summaries_max_depth=2
+summaries_titles_only_after_depth=2
 expand=false
 +++

--- a/content/docs/concepts/components/_index.md
+++ b/content/docs/concepts/components/_index.md
@@ -2,5 +2,6 @@
 title="Components"
 weight=1
 include_summaries=true
+summaries_max_depth=1
 expand=true
 +++

--- a/content/docs/concepts/components/lifecycle/_index.md
+++ b/content/docs/concepts/components/lifecycle/_index.md
@@ -2,7 +2,7 @@
 title="Lifecycle"
 weight=3
 include_summaries=true
-expand=false
+expand=true
 +++
 
 ## What is the lifecycle?

--- a/content/docs/concepts/components/lifecycle/_index.md
+++ b/content/docs/concepts/components/lifecycle/_index.md
@@ -2,7 +2,7 @@
 title="Lifecycle"
 weight=3
 include_summaries=true
-expand=true
+expand=false
 +++
 
 ## What is the lifecycle?

--- a/content/docs/concepts/components/lifecycle/analyze.md
+++ b/content/docs/concepts/components/lifecycle/analyze.md
@@ -4,6 +4,8 @@ weight=2
 summary="Restores files that buildpacks may use to optimize the build and export phases."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/build.md
+++ b/content/docs/concepts/components/lifecycle/build.md
@@ -4,6 +4,8 @@ weight=4
 summary="Transforms application source code into runnable artifacts that can be packaged into a container."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/create.md
+++ b/content/docs/concepts/components/lifecycle/create.md
@@ -4,6 +4,8 @@ weight=6
 summary="Runs detect, analyze, restore, build, and export in a single command."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/detect.md
+++ b/content/docs/concepts/components/lifecycle/detect.md
@@ -4,6 +4,8 @@ weight=1
 summary="Finds an ordered group of buildpacks to use during the build phase."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/export.md
+++ b/content/docs/concepts/components/lifecycle/export.md
@@ -4,6 +4,8 @@ weight=5
 summary="Creates the final OCI image."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/launch.md
+++ b/content/docs/concepts/components/lifecycle/launch.md
@@ -4,6 +4,8 @@ weight=7
 summary="The entrypoint for the final OCI image. Responsible for launching application processes."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code | Result|

--- a/content/docs/concepts/components/lifecycle/rebase.md
+++ b/content/docs/concepts/components/lifecycle/rebase.md
@@ -4,6 +4,8 @@ weight=8
 summary="Rebase application layers onto a new run image."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/content/docs/concepts/components/lifecycle/restore.md
+++ b/content/docs/concepts/components/lifecycle/restore.md
@@ -4,6 +4,8 @@ weight=3
 summary="Restores layers from the cache."
 +++
 
+{{< param "summary" >}}
+
 ### Exit Codes
 
 | Exit Code       | Result|

--- a/themes/buildpacks/layouts/partials/docs.html
+++ b/themes/buildpacks/layouts/partials/docs.html
@@ -14,7 +14,9 @@
         {{ .Content }}
 
         {{ if .Params.include_summaries }}
-          {{- template "subsection-summary" dict "currentSection" . "depth" 0 "titleOnlyAfterDepth" 1 -}}
+          {{- $titleOnlyAfterDepth := (int .Params.summaries_titles_only_after_depth | default 1) -}}
+          {{- $maxDepth := (int .Params.summaries_max_depth | default 2) -}}
+          {{- template "subsection-summary" dict "currentSection" . "depth" 0 "titleOnlyAfterDepth" $titleOnlyAfterDepth  "maxDepth" $maxDepth -}}
         {{ end }}
 
         {{ partial "footline.html" . }}
@@ -25,31 +27,40 @@
 
 <!-- templates -->
 {{- define "subsection-summary" }}
-  {{- $depth := .depth }}
+  {{- $depth := (int .depth) }}
+  {{- $maxDepth := (int .maxDepth) }}
   {{- $titleOnlyAfterDepth := .titleOnlyAfterDepth }}
-  {{- $headerLvl := (add (int $depth) 2) -}}
-  {{- with .currentSection}}
-    {{- $pages := (.Pages | union .Sections) }}
-    {{ range $pages }}
-      {{ if (ge $depth $titleOnlyAfterDepth) }}
-        <ul>
-          <li class="list-item-icon"><h{{ $headerLvl }}><a href="{{.Permalink}}" class="">{{ .Title }}</a></h{{ $headerLvl }}></li>
-          {{ if .Params.include_summaries }}
-            {{- template "subsection-summary" dict "currentSection" . "depth" (add (int $depth) 1)  "titleOnlyAfterDepth" $titleOnlyAfterDepth -}}
-          {{ end }}
-        </ul>
-      {{ else }}
-        <h{{ $headerLvl }}><a href="{{.Permalink}}" class="">{{ .Title | markdownify }}</a></h{{ $headerLvl }}>
-        <p class="m-1">{{ .Summary | replaceRE "<h[0-9].*>.*</h[0-9]>" "" | plainify | safeHTML }}</p>
-
-        {{ if .Params.include_summaries }}
-          {{- template "subsection-summary" dict "currentSection" . "depth" (add (int $depth) 1)  "titleOnlyAfterDepth" $titleOnlyAfterDepth -}}
+  {{- $headerLvl := (add $depth 2) -}}
+  {{- if (lt $depth $maxDepth) -}}
+    {{- with .currentSection}}
+      {{- $pages := sort (.Pages | union .Sections) "Weight" }}
+      {{ range $pages }}
+        {{ if (ge $depth $titleOnlyAfterDepth) }}
+          <ul>
+            <li class="list-item-icon"><h{{ $headerLvl }}><a href="{{.Permalink}}" class="">{{ .Title }}</a></h{{ $headerLvl }}></li>
+            {{ if .Params.include_summaries }}
+              {{- template "subsection-summary" dict "currentSection" . "depth" (add $depth 1)  "titleOnlyAfterDepth" $titleOnlyAfterDepth "maxDepth" $maxDepth -}}
+            {{ end }}
+          </ul>
         {{ else }}
-          <div class="text-md-right">
-            <a class="small text-pink mr-md-3 text-decoration-none" href="{{.Permalink}}">Learn more →</a>
-          </div>
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{- end}}
+          <h{{ $headerLvl }}><a href="{{.Permalink}}" class="">{{ .Title | markdownify }}</a></h{{ $headerLvl }}>
+          <p class="m-1">{{ .Summary | replaceRE "<h[0-9].*>.*</h[0-9]>" "" | plainify | safeHTML }}</p>
+
+          {{ if .Params.include_summaries }}
+            {{- template "subsection-summary" dict "currentSection" . "depth" (add $depth 1)  "titleOnlyAfterDepth" $titleOnlyAfterDepth "maxDepth" $maxDepth -}}
+
+            {{- if (eq (add $depth 1) $maxDepth) -}}
+            <div class="text-md-right">
+              <a class="small text-pink mr-md-3 text-decoration-none" href="{{.Permalink}}">Learn more →</a>
+            </div>
+            {{- end }}
+          {{ else }}
+            <div class="text-md-right">
+              <a class="small text-pink mr-md-3 text-decoration-none" href="{{.Permalink}}">Learn more →</a>
+            </div>
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end}}


### PR DESCRIPTION
This is a polishing PR for original #358 by @natalieparellano .

- Don't expand lifecycle phases in sidebar
- Adhere to weight property in Components page
- Show summaries on Concepts page

_The intent of this PR is solely to provide minor changes to the original in an effort to reduce friction in the review and merging process. As author of the original PR, if there are any questions, comments, or concerns, don't hesitate to reach out to the maintainers._

## Preview

![image](https://user-images.githubusercontent.com/475559/114463200-bdbd2500-9ba9-11eb-86b7-c4d40972e648.png)
![image](https://user-images.githubusercontent.com/475559/114463241-c9105080-9ba9-11eb-9c21-61d805a50719.png)
