### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,19 @@
+ports:
+  - port: 1313
+    onOpen: open-preview
+
+tasks:
+  - init: make build
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+
+vscode:
+  extensions:
+    - golang.go
+    - bierner.markdown-preview-github-styles

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@
 PACK_VERSION?=
 GITHUB_TOKEN?=
 PACK_BIN?=$(shell which pack)
+SERVE_PORT=1313
 BASE_URL?=
+
+ifndef BASE_URL
+ifdef GITPOD_WORKSPACE_URL
+BASE_URL=$(shell echo "$(GITPOD_WORKSPACE_URL)" | sed -r 's;^([^/]*)//(.*);\1//$(SERVE_PORT)-\2;')
+endif
+endif
 
 ifndef PACK_VERSION
 ifdef GITHUB_TOKEN
@@ -63,9 +70,9 @@ serve: export PACK_VERSION:=$(PACK_VERSION)
 serve: install-hugo pack-version pack-docs-update
 	@echo "> Serving..."
 ifeq ($(BASE_URL),)
-	hugo server --disableFastRender
+	hugo server --disableFastRender --port=$(SERVE_PORT)
 else
-	hugo server --disableFastRender --baseURL=$(BASE_URL) --appendPort=false
+	hugo server --disableFastRender --port=$(SERVE_PORT) --baseURL=$(BASE_URL) --appendPort=false
 endif
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)
+# Docs for [Cloud Native Buildpacks](https://buildpacks.io)
 
-Website for [Cloud Native Buildpacks](https://buildpacks.io)
+[![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)](https://github.com/buildpacks/docs/actions)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/pack)
+
+### Preview
 
 ![buildpacks.io](https://image.thum.io/get/https://buildpacks.io)
 


### PR DESCRIPTION
### Summary

This set of changes adds a small amount of configuration in order for setup on gitpod to be more "out-of-the-box". It properly maps the serving port and opens it in a preview.

### Before

![image](https://user-images.githubusercontent.com/475559/119397331-96bf3c00-bc9b-11eb-92cc-e8fa46685c2d.png)


### After 

![image](https://user-images.githubusercontent.com/475559/119397403-ad659300-bc9b-11eb-81eb-5f15c715f83f.png)
