### PR TITLE
Fix Slack button in community page

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,19 @@
+ports:
+  - port: 1313
+    onOpen: open-preview
+
+tasks:
+  - init: make build
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+
+vscode:
+  extensions:
+    - golang.go
+    - bierner.markdown-preview-github-styles

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@
 PACK_VERSION?=
 GITHUB_TOKEN?=
 PACK_BIN?=$(shell which pack)
+SERVE_PORT=1313
 BASE_URL?=
+
+ifndef BASE_URL
+ifdef GITPOD_WORKSPACE_URL
+BASE_URL=$(shell echo "$(GITPOD_WORKSPACE_URL)" | sed -r 's;^([^/]*)//(.*);\1//$(SERVE_PORT)-\2;')
+endif
+endif
 
 ifndef PACK_VERSION
 ifdef GITHUB_TOKEN
@@ -63,9 +70,9 @@ serve: export PACK_VERSION:=$(PACK_VERSION)
 serve: install-hugo pack-version pack-docs-update
 	@echo "> Serving..."
 ifeq ($(BASE_URL),)
-	hugo server --disableFastRender
+	hugo server --disableFastRender --port=$(SERVE_PORT)
 else
-	hugo server --disableFastRender --baseURL=$(BASE_URL) --appendPort=false
+	hugo server --disableFastRender --port=$(SERVE_PORT) --baseURL=$(BASE_URL) --appendPort=false
 endif
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)
+# Docs for [Cloud Native Buildpacks](https://buildpacks.io)
 
-Website for [Cloud Native Buildpacks](https://buildpacks.io)
+[![](https://github.com/buildpacks/docs/workflows/Deploy/badge.svg)](https://github.com/buildpacks/docs/actions)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/pack)
+
+### Preview
 
 ![buildpacks.io](https://image.thum.io/get/https://buildpacks.io)
 

--- a/themes/buildpacks/layouts/_default/community.html
+++ b/themes/buildpacks/layouts/_default/community.html
@@ -13,9 +13,9 @@
         <div
           class='docs-content text-white col-12 col-lg-5 d-flex justify-content-center justify-content-lg-start text-center text-lg-left'>
           <div>
-            <h1 class="mt-1 mb-3 text-white">Join our community</h1>
+            <h1 class="mt-1 mb-2 text-white">Join our community</h1>
             <div>
-              <script async defer src="https://slack.buildpacks.io/slackin.js?large"></script>
+              <a class="slack-button icon-button bg-pink shadow-sm button d-flex" href="https://slack.buildpacks.io/">Slack</a>
             </div>
             <div class="mt-3 text-left pl-4 pl-lg-0">
               <strong>Also...</strong>


### PR DESCRIPTION
# Summary

The previous slack button depended on slackin which we no longer use. This change now uses a simple static button.

_NOTE: Built on top of #371_

# Preview

![image](https://user-images.githubusercontent.com/475559/119400767-40a0c780-bca0-11eb-84b1-5a65e51f5ec0.png)
