### PR TITLE
Add contributor guide, link to community repo to community page

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -46,7 +46,7 @@ RFCs, or Request For Comments, is the process we employ to review project-wide c
 
 Contributions to the RFC process can take any or all of the following forms:
 - Reviewing and commenting on [RFC Pull Requests](https://github.com/buildpacks/rfcs/pulls)
-- Partaking in discussions in Working Group meetings
+- Partaking in discussions in [Working Group](https://github.com/buildpacks/community/#working-group) meetings
 - Proposing changes via [RFCs](https://github.com/buildpacks/rfcs)
 
 #### Triage

--- a/content/community.md
+++ b/content/community.md
@@ -5,6 +5,83 @@ layout="community"
 summary="Join other users, contributors and providers of Cloud Native Buildpacks."
 +++
 
+## What type of contributions can I make?
+
+Buildpacks welcomes all types of contributions, not just those related to code. We value any help that you can provide, and are more than happy to guide you through the process.
+
+#### Documentation
+
+This involves documenting any aspect of the project. We have various open issues for you to start off with. Another good starting point would revolve around your comprehension or desired area of expertise.
+
+Some examples where we'd value documentation contributions are:
+- Providing additional tutorials/guides to our [docs site](https://buildpacks.io/)
+- Adding additional information or examples to our [samples repo](https://github.com/buildpacks/samples)
+- Working on open issues, such as on our
+    - [Documentation repo](https://github.com/buildpacks/docs/issues)
+    - [Samples repo](https://github.com/buildpacks/samples/issues)
+- Adding GoDocs to codebases, such as
+    - [libcnb](https://github.com/buildpacks/libcnb)
+    - [lifecycle](https://github.com/buildpacks/lifecycle)
+    - [pack](https://github.com/buildpacks/pack)
+- Writing posts for our [Medium blog](https://medium.com/buildpacks). Please discuss blog proposals with the [learning team on Slack](https://buildpacks.slack.com/archives/CST4A3ECV).
+
+If you have any other ideas where documentation would be useful, please feel free to open up an issue in the related repository, or drop a message at the [#docs channel on Slack!](https://buildpacks.slack.com/archives/CDLN5A3TL) 
+
+#### Code
+
+Code contributions are always welcome to any Buildpacks repository. 
+
+The following repositories are good starting points for code contributions:
+- [libcnb](https://github.com/buildpacks/libcnb)
+- [lifecycle](https://github.com/buildpacks/lifecycle)
+- [pack](https://github.com/buildpacks/pack)
+
+Other, more specialized, repositories include:
+- [tekton-integration](https://github.com/buildpacks/tekton-integration)
+- [pack-orb](https://github.com/buildpacks/pack-orb)
+
+#### RFCs
+
+RFCs, or Request For Comments, is the process we employ to review project-wide changes. By proposing changes via RFCs, it allows for the entire community to partake in the brainstorming process of applying changes, considering alternatives, impact, and limitations.
+
+Contributions to the RFC process can take any or all of the following forms:
+- Reviewing and commenting on [RFC Pull Requests](https://github.com/buildpacks/rfcs/pulls)
+- Partaking in discussions in Working Group meetings
+- Proposing changes via [RFCs](https://github.com/buildpacks/rfcs)
+
+#### Triage
+
+Triaging issues is the process of looking at newly created issues (or following up on issues). There are many benefits our community gains from our current triage process, such as:
+- The community receives reasonable response times.
+- Minimize the number of open "stale" issues.
+- Ongoing efforts aren't disrupted.
+
+To learn more about how you can help triage issues, check out our dedicated [triage](https://github.com/buildpacks/community/blob/main/contributors/triage.md) page.
+
+If you're looking at open issues but unsure where to start, try looking for issues with the "good first issue" or "help wanted" labels!
+
+## How do I submit a pull request?
+
+If your contribution requires changes to a project repository, look at the DEVELOPMENT.md file if the repo has one to ensure you have the prerequisites installed. It may also include other necessary steps (such as instructions on running tests), but broadly, you will have to carry out the following steps:
+- [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository.
+- [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository) your fork repository.
+- Create a branch for the issue: `git checkout -b {{BRANCH_NAME}}`
+- Make any changes deemed necessary.
+- Commit your changes with a sign-off: `git commit -s`
+
+A sign-off is a single line added to your commit messages that certifies that you wrote and/or have the right to the contributed changes. The signature should look as such:
+```
+Signed-off-by: John Doe <john.doe@email.com>
+```
+Also, git can automatically add the signature by adding the -s flag to the commit command,
+`git commit -s`
+
+The full text of the certification is available [here](https://developercertificate.org/). 
+
+- Push to GitHub: `git push origin {{BRANCH_NAME}}`
+- [Create the pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+
+
 ## Calendar
 
 Partake in one or many of our following public events:

--- a/themes/buildpacks/layouts/_default/community.html
+++ b/themes/buildpacks/layouts/_default/community.html
@@ -21,6 +21,7 @@
               <strong>Also...</strong>
               <ul class="text-left">
                 <li><a href="https://github.com/buildpacks/community/discussions">GitHub Discussions</a></li>
+                <li><a href="https://github.com/buildpacks/community">BuildPacks Community on GitHub</a></li>
                 <li><a href="https://lists.cncf.io/g/cncf-buildpacks">Mailing List</a></li>
                 <li><a href="https://stackoverflow.com/questions/tagged/buildpack">StackOverflow</a></li>
               </ul>


### PR DESCRIPTION
- Added the community repo link to the html
- I've made the other changes to the community.md file. I reckon it will require some formatting, as I could not preview the changes myself. Is there a way to see the changes locally? 
- Should I look at jinja for syntax details or somewhere else? 
- Could not add a link for working group in RFCs section as the current link is broken (please see [here](https://github.com/buildpacks/community/issues/108))
In addition to the above, please let me know if any changes are to be made to the content itself.

See #373 and #357

cc: @jromero 