### PR TITLE
feat: install latest hugo according to platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ content/docs/tools/pack/cli/pack*
 # Tools
 /bin
 /tmp
+
+/tools/bin

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,17 @@ clean:
 .PHONY: install-hugo
 install-hugo:
 	@echo "> Installing hugo..."
-	cd tools; go install -mod=mod --tags extended github.com/gohugoio/hugo
+	@echo "This may take a while depending on your connection."
+ifeq ($(OS),Windows_NT)
+	@echo $(shell uname -s)	
+	cd tools; mkdir bin; cd bin; curl -L -O $(shell curl https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.assets[30].browser_download_url')
+	
+else
+	@echo $(shell uname -s)
+	cd tools; mkdir bin; cd bin; curl -L -O $(shell curl https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.assets[26].browser_download_url')	
+endif
+
+	
 
 .PHONY: upgrade-pack
 upgrade-pack: pack-version


### PR DESCRIPTION
### Summary
The approach here uses the GitHub API to fetch the `browser_download_url` which is obtained by parsing the JSON response. For windows, this gets the latest zip file of Hugo extended for windows OS. However, the implementation for Mac, Linux is a work in progress.


Signed-off-by: Harshita-Kanal <harshita.kgv@gmail.com>