### PR TITLE
Call out the default project descirptor location.

### DIFF
--- a/content/docs/app-developer-guide/environment-variables.md
+++ b/content/docs/app-developer-guide/environment-variables.md
@@ -87,6 +87,7 @@ The following environment variables were set and available to buildpacks at buil
 
 ### Using Project Descriptor
 The `--descriptor` parameter must be a path to a file which follows the project.toml [schema][descriptor-schema].
+Without the `--descriptor` flag, `pack build` will use the `project.toml` file in the application directory if it exists.
 You can define environment variables in an `env` table in the file, and pass those into the application.
 
 ##### Example:


### PR DESCRIPTION
Without that, the example is confusing since it does not use the `--descriptor` flag.

Signed-off-by: Mikey Boldt <mboldt@vmware.com>

> _By signing off you acknowledge adhering to the requirements listed here: https://probot.github.io/apps/dco/_