### PR TITLE
Add community calendar

### DIFF
--- a/data/calendar.yml
+++ b/data/calendar.yml
@@ -7,6 +7,9 @@ subcalendars:
   #   - id: teamup id
   #   - name: human readable name
   #   - color: html color of events on calendar
+  - id: 10287223
+    name: Community
+    color: '#4aaace'
   - id: 9330130
     name: Office Hours
     color: '#2951b9'


### PR DESCRIPTION
## Summary

Adds a community calendar for community events.

The first event on the calendar is the recurring kpack working group. (cc: @matthewmcnew)

## Preview

![image](https://user-images.githubusercontent.com/475559/144043466-541f0cf6-dade-4223-b49c-fc726fc2462c.png)
