### PR TITLE
Fix content overlaying search dropdown in Getting started

### DIFF
--- a/themes/buildpacks/assets/scss/components/_docs.scss
+++ b/themes/buildpacks/assets/scss/components/_docs.scss
@@ -27,6 +27,7 @@
     border-right: 1px solid $off-gray;
     position: relative;
     max-width: 400px;
+    z-index: 1;
     &:before {
       content: "";
       position: absolute;
@@ -35,7 +36,6 @@
       width: 5px;
       height: 100%;
       background: linear-gradient(to right, rgba($gray-light, 0), rgba($gray-light, 0.05));
-      z-index: 1;
       pointer-events: none;
     }
     @media (max-width: 767px) {


### PR DESCRIPTION
Fixes #419

# Screenshots
![Fix content overlaying search dropdown in Getting started](https://user-images.githubusercontent.com/71175492/145008848-8332f768-d1fb-4b7e-a2ce-224cf6b811ea.png)


Signed-off-by: Prabin <acharyaprabin101@gmail.com

