### PR TITLE
Fix typo in name of flag

### DIFF
--- a/content/docs/app-developer-guide/using-cache-image.md
+++ b/content/docs/app-developer-guide/using-cache-image.md
@@ -19,7 +19,7 @@ The `--cache-image` parameter must be in the following format
 --cache-image <remote-image-location>
 ```
 
-The `--cache-images` flag must be specified in conjunction with the `--publish` flag.
+The `--cache-image` flag must be specified in conjunction with the `--publish` flag.
 
 ### Examples
 For the following examples we will use:

--- a/katacoda/scenarios/app-developer-guide/using-cache-image.md
+++ b/katacoda/scenarios/app-developer-guide/using-cache-image.md
@@ -14,7 +14,7 @@ The `--cache-image` parameter must be in the following format
 --cache-image <remote-image-location>
 ```
 
-The `--cache-images` flag must be specified in conjunction with the `--publish` flag.
+The `--cache-image` flag must be specified in conjunction with the `--publish` flag.
 
 ### Examples
 For the following examples we will use:


### PR DESCRIPTION
Fix typo in name of flag and fold typo fix in to katacoda
docs.