### PR TITLE
move to slack links to CNCF slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Community Slack
-    url: https://slack.buildpacks.io/
+    url: https://slack.cncf.io
     about: Chat with the community about any issues, questions, or feedback

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Calendar
 
-The calendar is managed via [teamup](https://teamup.com/ksxw26c3km72mq3imn). To request an alteration you may [create an issue](https://github.com/buildpacks/community/issues/new), reach out to a maintainer via [slack](https://slack.buildpacks.io), post in [discussions](https://github.com/buildpacks/community/discussions).
+The calendar is managed via [teamup](https://teamup.com/ksxw26c3km72mq3imn). To request an alteration you may [create an issue](https://github.com/buildpacks/community/issues/new), reach out to a maintainer via [slack](https://slack.cncf.io), post in [discussions](https://github.com/buildpacks/community/discussions).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Calendar
 
-The calendar is managed via [teamup](https://teamup.com/ksxw26c3km72mq3imn). To request an alteration you may [create an issue](https://github.com/buildpacks/community/issues/new), reach out to a maintainer via [slack](https://slack.cncf.io), post in [discussions](https://github.com/buildpacks/community/discussions).
+The calendar is managed via [teamup](https://teamup.com/ksxw26c3km72mq3imn). To request an alteration you may [create an issue](https://github.com/buildpacks/community/issues/new), reach out to a maintainer via [slack](https://slack.cncf.io) in #buildpacks-maintainers, post in [discussions](https://github.com/buildpacks/community/discussions).
 
 ## Contributing
 

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ unsafe= true
 [params]
 twitter_handle = "buildpacks_io"
 github_base_url = "https://github.com/buildpacks"
-slack_invite_url = "https://slack.buildpacks.io/"
+slack_invite_url = "https://slack.cncf.io"
 description = "Cloud Native Buildpacks transform your application source code into images that can run on any cloud."
 
 pack_version_env_var = "PACK_VERSION"
@@ -66,7 +66,7 @@ pack_version_env_var = "PACK_VERSION"
 
   [[menu.footer2]]
   name       = "Slack"
-  url        = "https://slack.buildpacks.io/"
+  url        = "https://slack.cncf.io"
   weight     = 2
 
   [[menu.footer2]]

--- a/content/community.md
+++ b/content/community.md
@@ -51,9 +51,9 @@ Some examples where we'd value documentation contributions are:
   - [libcnb](https://github.com/buildpacks/libcnb)
   - [lifecycle](https://github.com/buildpacks/lifecycle)
   - [pack](https://github.com/buildpacks/pack)
-- Writing posts for our [Medium blog](https://medium.com/buildpacks). Please discuss blog proposals with the [learning team on Slack](https://buildpacks.slack.com/archives/CST4A3ECV).
+- Writing posts for our [Medium blog](https://medium.com/buildpacks). Please discuss blog proposals with the [learning team on Slack, #buildpacks-learning-team](https://cloud-native.slack.com/app_redirect?channel=buildpacks-learning-team).
 
-If you have any other ideas where documentation would be useful, please feel free to open up an issue in the related repository, or drop a message at the [#docs channel on Slack!](https://buildpacks.slack.com/archives/CDLN5A3TL)
+If you have any other ideas where documentation would be useful, please feel free to open up an issue in the related repository, or drop a message at the [#buildpacks-learning-team channel on Slack!](https://cloud-native.slack.com/app_redirect?channel=buildpacks-learning-team)
 
 {{< /tab >}}
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -50,7 +50,7 @@ Cloud Native Buildpacks is an incubating project in the CNCF. We welcome contrib
 
 ## Community
 
-The best place to contact the Cloud Native Buildpack team is on our [Slack channel](https://slack.buildpacks.io/) or [mailing list](https://lists.cncf.io/g/cncf-buildpacks).
+The best place to contact the Cloud Native Buildpack team is on the [CNCF Slack](https://slack.cncf.io/) in the #buildpacks or [mailing list](https://lists.cncf.io/g/cncf-buildpacks).
 
 ## Contributor's Guide
 

--- a/themes/buildpacks/layouts/_default/community.html
+++ b/themes/buildpacks/layouts/_default/community.html
@@ -15,7 +15,8 @@
           <div>
             <h1 class="mt-1 mb-2 text-white">Join our community</h1>
             <div>
-              <a class="slack-button icon-button bg-pink shadow-sm button d-flex" href="https://slack.buildpacks.io/">Slack</a>
+              <a class="slack-button icon-button bg-pink shadow-sm button d-flex" href="https://slack.cncf.io/">Slack</a>
+	      Find us in the <a href="https://cloud-native.slack.com/app_redirect?channel=buildpacks">#buildpacks</a> channel.
             </div>
             <div class="mt-3 text-left pl-4 pl-lg-0">
               <strong>Also...</strong>


### PR DESCRIPTION
TODO:
- [ ] update `content/community.md` to point to https://slack.cncf.io after migration

Should we have instructions somewhere about the #buildpacks channels to find us or will people be able to figure it out?