### PR TITLE
Expand current sidebar node

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/build-app.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/build-app.md
@@ -130,8 +130,6 @@ You will see the following output:
 ```
 ===> DETECTING
 ...
-===> ANALYZING
-...
 ===> RESTORING
 ===> BUILDING
 ---> Ruby Buildpack

--- a/content/docs/buildpack-author-guide/create-buildpack/detection.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/detection.md
@@ -39,7 +39,6 @@ You should see the following output:
 
 <!-- test:assert=contains -->
 ```
-===> ANALYZING
 Previous image with name "test-ruby-app" not found
 ===> DETECTING
 examples/ruby 0.0.1

--- a/katacoda/scenarios/buildpack-author-guide/build-app.md
+++ b/katacoda/scenarios/buildpack-author-guide/build-app.md
@@ -126,8 +126,6 @@ You will see the following output:
 ```
 ===> DETECTING
 ...
-===> ANALYZING
-...
 ===> RESTORING
 ===> BUILDING
 ---> Ruby Buildpack

--- a/katacoda/scenarios/buildpack-author-guide/detection.md
+++ b/katacoda/scenarios/buildpack-author-guide/detection.md
@@ -35,7 +35,6 @@ You should see the following output:
 
 <!-- test:assert=contains -->
 ```
-===> ANALYZING
 Previous image with name "test-ruby-app" not found
 ===> DETECTING
 examples/ruby 0.0.1

--- a/themes/buildpacks/layouts/partials/sidebar.html
+++ b/themes/buildpacks/layouts/partials/sidebar.html
@@ -52,7 +52,7 @@
   {{- if ne $numberOfPages 0 }}
   {{- $depth = add (int $depth) 1 }}
   <ul class="ml-2">
-    {{- $expand = .Params.expand -}}
+    {{- $expand = (or .Params.expand $isCurrent) -}}
     {{- $pages := (.Pages | union .Sections) }}
     {{- range $pages.ByWeight }}
     {{- if (not .Params.hidden) }}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bep/gitmap v1.3.0 // indirect
 	github.com/buildpacks/lifecycle v0.14.1 // indirect
-	github.com/buildpacks/pack v0.26.0
+	github.com/buildpacks/pack v0.27.0
 	github.com/clbanning/mxj/v2 v2.5.6 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
 	github.com/containerd/containerd v1.6.6 // indirect
@@ -32,6 +32,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.2 // indirect
 	github.com/rivo/tview v0.0.0-20220610163003-691f46d6f500 // indirect
 	github.com/spf13/cobra v1.4.0
+	github.com/spf13/viper v1.10.0 // indirect
 	github.com/tdewolff/minify/v2 v2.11.9 // indirect
 	github.com/tdewolff/parse/v2 v2.6.0 // indirect
 	gocloud.dev v0.25.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -450,6 +450,8 @@ github.com/buildpacks/lifecycle v0.14.1 h1:CkMsUbotZvru+VOTn08BWPbJRZnAx6Xx2yQYo
 github.com/buildpacks/lifecycle v0.14.1/go.mod h1:l8p/hrNzwq1Dr9JEblxC8ZHOLhJPCBFOPCwyo0Z66/Y=
 github.com/buildpacks/pack v0.26.0 h1:R0yPwTz58MfcqYSA0B2Q8ksOhp2Rz5kE/hO2BVys2y4=
 github.com/buildpacks/pack v0.26.0/go.mod h1:6y/OxdE5ewaBuazvO4FKHvs2wEjA6DKI6e00WwZBuwM=
+github.com/buildpacks/pack v0.27.0 h1:diMvn/aR0wbfs0ke7DOBtrkFzJqDw+moJPTWLdUTuhE=
+github.com/buildpacks/pack v0.27.0/go.mod h1:ifPVxBoY2EKbSrA8Hkyy0YFfSGCzyYnzlyjrLsxxAIY=
 github.com/butuzov/ireturn v0.1.1/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
When a user selects a sidebar menu entry, expand all the direct
children of that entry.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>