### PR TITLE
Revert "Promote guides to second level header"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,21 +81,6 @@ featureKatacoda = false
   url        = "https://github.com/buildpacks"
   weight     = 4
 
-  [[menu.docs]]
-  name       = "Application Developer Guide"
-  url        = "/docs/app-developer-guide"
-  weight     = 1
-
-  [[menu.docs]]
-  name       = "Buildpack Author Guide"
-  url        = "/docs/buildpack-author-guide"
-  weight     = 2
-
-  [[menu.docs]]
-  name       = "Platform Operator Guide"
-  url        = "/docs/operator-guide/"
-  weight     = 3
-
 [security]
   enableInlineShortcodes = false
   [security.exec]

--- a/themes/buildpacks/layouts/partials/header.html
+++ b/themes/buildpacks/layouts/partials/header.html
@@ -30,14 +30,4 @@
       <a class="github-button icon-button bg-blue button d-none d-lg-flex" href="https://github.com/buildpacks">GitHub</a>
     </div>
   </nav>
-
-  <nav id="subnav" class="navbar navbar-expand-sm" role="navigation">
-    <ul class="nav navbar-nav">
-      {{ range $.Site.Menus.docs }}
-      <li class="nav-link text-center">
-        <a class="nav-link py-2 py-lg-0 px-1" href="{{.URL}}">{{.Name}}</a>
-      </li>
-      {{ end }}
-    </ul>
-  </nav>
 </header>

--- a/themes/buildpacks/layouts/partials/sidebar.html
+++ b/themes/buildpacks/layouts/partials/sidebar.html
@@ -52,7 +52,7 @@
   {{- if ne $numberOfPages 0 }}
   {{- $depth = add (int $depth) 1 }}
   <ul class="ml-2">
-    {{- $expand = (or $isCurrent) -}}
+    {{- $expand = (or .Params.expand $isCurrent) -}}
     {{- $pages := (.Pages | union .Sections) }}
     {{- range $pages.ByWeight }}
     {{- if (not .Params.hidden) }}


### PR DESCRIPTION
Reverts buildpacks/docs#539

I just noticed that this section bleeds into the homepage and looks very weird with multiple top navigation bars.

![Screenshot_2022-12-22-18-50-39-38_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/16130816/209143106-7c043209-81f7-4dda-8fe3-5a49b77edcef.jpg)

![Screenshot_2022-12-22-18-51-50-06_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/16130816/209143257-67752555-5e1f-4664-a534-ad27b3ccafde.jpg)


It also isn't responsive and looks bad on mobile screens. Reverting it for now until we can figure out a better way to display this. Ideally we should have something like - 
![Screenshot_2022-12-22-18-45-13-05_abb9c8060a0a12c5ac89e934e52a2f4f](https://user-images.githubusercontent.com/16130816/209142262-ac3c9be0-6b8e-4dc5-b696-6c08c4c0b2ad.jpg)

Notice the 'which are you' section 

https://web.archive.org/web/20210511112502/https://www.seldon.io/tech/
