### PR TITLE
docs: update GitHub Actions dependencies in sample

### DIFF
--- a/content/docs/buildpack-author-guide/publishing-with-github-actions.md
+++ b/content/docs/buildpack-author-guide/publishing-with-github-actions.md
@@ -34,7 +34,7 @@ jobs:
     - ubuntu-latest
     steps:
     - id: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
       uses: docker/login-action@v1
       with:
@@ -42,7 +42,7 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_PASS }}
     - id: setup-pack
-      uses: buildpacks/github-actions/setup-pack@v4.4.0
+      uses: buildpacks/github-actions/setup-pack@v4.9.0
     - id: package
       run: |
         #!/usr/bin/env bash
@@ -59,7 +59,7 @@ jobs:
       env:
         REPO: docker.io/${{ secrets.DOCKER_HUB_USER }}
     - id: register
-      uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.4.0
+      uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.9.0
       with:
         token:   ${{ secrets.PUBLIC_REPO_TOKEN }}
         id:      ${{ steps.package.outputs.bp_id }}


### PR DESCRIPTION
In particular, the actions/checkout version is deprecated and will stop working soonish.

Signed-off-by: Lars Gyrup Brink Nielsen <larsbrinknielsen@gmail.com>