### PR TITLE
Remove requirement to sync katacoda docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Check links
         run: |
           make check-links
-      - name: Check katacoda
-        run: |
-          make check-katacoda
       - name: Upload public folder
         uses: actions/upload-artifact@v3
         env:


### PR DESCRIPTION
Deemphasize katacoda in our docs.  We have been told that it is unlikely to be available in any form in future.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>