### PR TITLE
Move inline buildpacks docs to Extension Author Guide

### DIFF
--- a/content/docs/extension-author-guide/_index.md
+++ b/content/docs/extension-author-guide/_index.md
@@ -1,5 +1,5 @@
 +++
-title="Extension Author Guide"
+title="Extending Buildpacks"
 weight=4
 include_summaries=true
 expand=true

--- a/content/docs/extension-author-guide/create-extension/_index.md
+++ b/content/docs/extension-author-guide/create-extension/_index.md
@@ -1,6 +1,6 @@
 +++
 title="Create an extension"
-weight=4
+weight=1
 summary="This is a step-by-step tutorial for creating and using CNB image extensions"
 +++
 

--- a/content/docs/extension-author-guide/inline-buildpacks/_index.md
+++ b/content/docs/extension-author-guide/inline-buildpacks/_index.md
@@ -1,0 +1,15 @@
++++
+title="Inline Extensions"
+weight=2
+summary="This is a step-by-step tutorial for creating and using CNB inline buildpacks"
++++
+
+## Overview
+
+The `build` process can be extended by end-users who provide a command to execute within the project desciptor (`project.toml`) of their application source code.
+
+<!--+if false+-->
+---
+
+<a href="/docs/extension-author-guide/inline-buildpacks/using-inline-buildpacks" class="button bg-pink">Start Tutorial</a>
+<!--+end+-->

--- a/content/docs/extension-author-guide/inline-buildpacks/using-inline-buildpacks.md
+++ b/content/docs/extension-author-guide/inline-buildpacks/using-inline-buildpacks.md
@@ -1,6 +1,6 @@
 +++
 title="Using Inline Buildpacks"
-weight=7
+weight=1
 summary="Learn how to create an ephemeral buildpack to customize your build."
 +++
 


### PR DESCRIPTION
Take advantage of the new Dockerfiles extensions docs to consolidate our docs around extending the build process in a single section.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>