### PR TITLE
Update Gemfile in buildpack author guide

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/setup-local-environment.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/setup-local-environment.md
@@ -46,11 +46,12 @@ Then, create a file called `ruby-sample-app/Gemfile`<!--+"{{open}}"+--> with the
 
 <!-- test:file=ruby-sample-app/Gemfile -->
 ```ruby
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "sinatra"
+gem 'sinatra'
+gem 'webrick'
 ```
 
 Finally, make sure your local Docker daemon is running by executing:


### PR DESCRIPTION
Ruby 3+ no longer includes webrick so it has to be explicitly required in the Gemfile for the app to start. Otherwise you'll get errors like this later on in the tutorial:

```
/layers/examples_ruby/ruby/lib/ruby/gems/3.1.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1755:in `detect_rack_handler': Server handler (thin,puma,reel,HTTP,webrick) not found. (RuntimeError)
	from /layers/examples_ruby/ruby/lib/ruby/gems/3.1.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1493:in `run!'
	from /layers/examples_ruby/ruby/lib/ruby/gems/3.1.0/gems/sinatra-2.1.0/lib/sinatra/main.rb:45:in `block in <module:Sinatra>'
```

See https://bugs.ruby-lang.org/issues/17303 for more details on the `webrick` removal. I also changed some of the string literals to use single quotes since that's more idiomatic in Ruby.

