### PR TITLE
Fix hugo download on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 endif
 
 ifeq ($(shell uname -s),Darwin)
-	HUGO_OS:=macOS
+	HUGO_OS:=darwin
 	HUGO_ARCH:=universal
 endif
 


### PR DESCRIPTION
This PR fixes an error downloading hugo on macOS when no installation is available

Fixes #572 