### PR TITLE
Add Rebasable label small description and updated inspect-image outputs

### DIFF
--- a/content/docs/app-developer-guide/run-an-app.md
+++ b/content/docs/app-developer-guide/run-an-app.md
@@ -49,8 +49,6 @@ Base Image:
 
 Run Images:
   cnbs/sample-stack-run:alpine
-  
-Rebasable: true
 
 Buildpacks:
   ID                             VERSION           HOMEPAGE

--- a/content/docs/app-developer-guide/run-an-app.md
+++ b/content/docs/app-developer-guide/run-an-app.md
@@ -49,6 +49,8 @@ Base Image:
 
 Run Images:
   cnbs/sample-stack-run:alpine
+  
+Rebasable: true
 
 Buildpacks:
   ID                             VERSION           HOMEPAGE

--- a/content/docs/app-developer-guide/run-an-app.md
+++ b/content/docs/app-developer-guide/run-an-app.md
@@ -50,6 +50,8 @@ Base Image:
 Run Images:
   cnbs/sample-stack-run:alpine
 
+Rebasable: true
+
 Buildpacks:
   ID                             VERSION           HOMEPAGE
   samples/java-maven             0.0.1             https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven

--- a/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
@@ -10,6 +10,7 @@ One of the benefits of buildpacks is they can also populate the app image with m
 * The process types that are available and the commands associated with them
 * The run-image the app image was based on
 * The buildpacks were used to create the app image
+* Whether the run-image can be rebased with a new version through the `Rebasable` label or not
 * And more...!
 
 You can find some of this information using `pack` via its `inspect-image` command.  The bill-of-materials information will be available using `pack sbom download`.
@@ -25,6 +26,8 @@ You should see the following:
 ```text
 Run Images:
   cnbs/sample-stack-run:jammy
+
+Rebasable: false
 
 Buildpacks:
   ID                   VERSION        HOMEPAGE

--- a/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
@@ -26,6 +26,8 @@ You should see the following:
 ```text
 Run Images:
   cnbs/sample-stack-run:jammy
+  
+Rebasable: true
 
 Buildpacks:
   ID                   VERSION        HOMEPAGE

--- a/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
@@ -27,8 +27,6 @@ You should see the following:
 Run Images:
   cnbs/sample-stack-run:jammy
 
-Rebasable: false
-
 Buildpacks:
   ID                   VERSION        HOMEPAGE
   examples/ruby        0.0.1          -

--- a/katacoda/scenarios/app-developer-guide/run-an-app.md
+++ b/katacoda/scenarios/app-developer-guide/run-an-app.md
@@ -42,8 +42,6 @@ Base Image:
 Run Images:
   cnbs/sample-stack-run:alpine
 
-Rebasable: true
-
 Buildpacks:
   ID                             VERSION           HOMEPAGE
   samples/java-maven             0.0.1             https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven

--- a/katacoda/scenarios/app-developer-guide/run-an-app.md
+++ b/katacoda/scenarios/app-developer-guide/run-an-app.md
@@ -42,6 +42,8 @@ Base Image:
 Run Images:
   cnbs/sample-stack-run:alpine
 
+Rebasable: true
+
 Buildpacks:
   ID                             VERSION           HOMEPAGE
   samples/java-maven             0.0.1             https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven


### PR DESCRIPTION
Update the documentation about the `Rebasable` feature implementation
PR: https://github.com/buildpacks/pack/pull/1806
Issue: https://github.com/buildpacks/pack/issues/1799

Changes:
* Added a small description of the `Rebasable` label
* Updated the inspect-image outputs