### PR TITLE
Add missing `schema-version` properties

### DIFF
--- a/content/docs/app-developer-guide/specify-buildpacks.md
+++ b/content/docs/app-developer-guide/specify-buildpacks.md
@@ -9,14 +9,14 @@ summary="Learn how to specify exactly what buildpacks are used during the build 
 
 You may specify exactly what buildpacks are used during the build process by referencing them with a URI in any of the following formats.
 
-| Type | Format |
-|----- |------- |
-| Relative | `<path>` |
-| Filesystem | `file://[<host>]/<path>` |
-| URL | `http[s]://<host>/<path>` |
-| Docker | `docker://[<host>]/<path>[:<tag>⏐@<digest>]` |
-| CNB Builder Resource | `urn:cnb:builder[:<id>[@<version>]]` |
-| CNB Registry Resource | `urn:cnb:registry[:<id>[@<version>]]` |
+| Type                  | Format                                       |
+| --------------------- | -------------------------------------------- |
+| Relative              | `<path>`                                     |
+| Filesystem            | `file://[<host>]/<path>`                     |
+| URL                   | `http[s]://<host>/<path>`                    |
+| Docker                | `docker://[<host>]/<path>[:<tag>⏐@<digest>]` |
+| CNB Builder Resource  | `urn:cnb:builder[:<id>[@<version>]]`         |
+| CNB Registry Resource | `urn:cnb:registry[:<id>[@<version>]]`        |
 
 ##### Fallback Behavior
 
@@ -60,7 +60,7 @@ The [`project.toml`][project-toml] format allows for Buildpack URIs to be specif
 
 ```toml
 [_]
-schema-version = "0.3"
+schema-version = "0.2"
 id = "sample-java-maven-app"
 name = "Sample Java App"
 version = "1.0.0"

--- a/content/docs/app-developer-guide/using-project-descriptor.md
+++ b/content/docs/app-developer-guide/using-project-descriptor.md
@@ -20,6 +20,7 @@ file at the root of the application. For more on `gitignore` matching see [these
 
 ```toml
 [_]
+schema-version = "0.2"
 id = "io.buildpacks.bash-script"
 name = "Bash Script"
 version = "1.0.0"
@@ -68,6 +69,7 @@ Below is an expanded `project.toml`, with an additional buildpack and environmen
 
 ```toml
 [_]
+schema-version = "0.2"
 id = "io.buildpacks.bash-script"
 name = "Bash Script"
 version = "1.0.0"

--- a/content/docs/reference/config/project-descriptor.md
+++ b/content/docs/reference/config/project-descriptor.md
@@ -15,6 +15,9 @@ The schema for the `project descriptor` is:
 - #### `_` _(table, optional)_
   A configuration table for a project.
 
+  - **`schema-version`** _(string, optional)_\
+    A version identifier for the schema of the `_` table and structure of the project descriptor file. It is a string that follows the format of the [Buildpack API Version](https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpack-api-version). The schema is documented [in the project descriptor specification](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md#schema-version) and is presently `0.2`.
+
   - **`id`** _(string, optional)_\
     A machine readable identifier for the `project`. For example, `com.example.myservice`.
 


### PR DESCRIPTION
Updates a few examples to include `schema-version` and adds a description of `schema-version` which links to spec materials.

Also, updates one page which had the `schema-version` set to `0.3`, which as far as I can tell is a typo.