### PR TITLE
Fix extensions demo now that samples repo has been updated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pack
         uses: buildpacks/github-actions/setup-pack@v5.2.0
         with:
-          pack-version: '0.30.0-pre3'
+          pack-version: '0.30.0-rc1'
       - name: Test
         run: make test
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pack
         uses: buildpacks/github-actions/setup-pack@v5.2.0
         with:
-          pack-version: '0.28.0'
+          pack-version: '0.30.0-pre3'
       - name: Test
         run: make test
         env:

--- a/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/adding-bill-of-materials.md
@@ -21,10 +21,11 @@ pack inspect-image test-ruby-app
 <!--+- "{{execute}}"+-->
 You should see the following:
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```text
 Run Images:
   cnbs/sample-stack-run:jammy
+...
 
 Buildpacks:
   ID                   VERSION        HOMEPAGE

--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -116,10 +116,12 @@ The `pack build` command takes in your Ruby sample app as the `--path` argument 
 
 After running the command, you should see that it failed to detect, as the `detect` script is currently written to simply error out.
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```
 ===> DETECTING
+...
 err:  examples/ruby@0.0.1 (1)
+...
 ERROR: No buildpack groups passed detection.
 ERROR: failed to detect: buildpack(s) failed with err
 ```

--- a/content/docs/buildpack-author-guide/create-buildpack/caching.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/caching.md
@@ -256,6 +256,7 @@ it will download the gems:
 <!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby
 ---> Installing gems
@@ -274,6 +275,7 @@ you will see the new caching logic at work during the `BUILDING` phase:
 <!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby
 ---> Reusing gems

--- a/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
@@ -126,9 +126,10 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 You will notice that version of Ruby specified in the app's `.ruby-version` file is downloaded.
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby 3.1.0
 ```

--- a/content/docs/extension-guide/create-extension/build-dockerfile.md
+++ b/content/docs/extension-guide/create-extension/build-dockerfile.md
@@ -8,25 +8,25 @@ aliases = [
 
 <!-- test:suite=dockerfiles;weight=4 -->
 
-### Examine `tree` extension
+### Examine `vim` extension
 
 #### detect
 
 <!-- test:exec -->
 ```bash
-cat $PWD/samples/extensions/tree/bin/detect
+cat $PWD/samples/extensions/vim/bin/detect
 ```
 
-The extension always detects (because its exit code is `0`) and provides a dependency called `tree` by writing to the build plan.
+The extension always detects (because its exit code is `0`) and provides a dependency called `vim` by writing to the build plan.
 
 #### generate
 
 <!-- test:exec -->
 ```bash
-cat $PWD/samples/extensions/tree/bin/generate
+cat $PWD/samples/extensions/vim/bin/generate
 ```
 
-The extension generates a `build.Dockerfile` that installs `tree` on the builder image.
+The extension generates a `build.Dockerfile` that installs `vim` on the builder image.
 
 ### Re-build the application image
 
@@ -35,7 +35,7 @@ The extension generates a `build.Dockerfile` that installs `tree` on the builder
 pack build hello-extensions \
   --builder localhost:5000/extensions-builder \
   --env BP_EXT_DEMO=1 \
-  --env BP_REQUIRES=tree \
+  --env BP_REQUIRES=vim \
   --network host \
   --path $PWD/samples/apps/java-maven \
   --pull-policy always \
@@ -48,19 +48,19 @@ You should see:
 
 ```
 [detector] ======== Results ========
-[detector] pass: samples/tree@0.0.1
+[detector] pass: samples/vim@0.0.1
 [detector] pass: samples/hello-extensions@0.0.1
 [detector] Resolving plan... (try #1)
-[detector] samples/tree             0.0.1
+[detector] samples/vim             0.0.1
 [detector] samples/hello-extensions 0.0.1
-[detector] Running generate for extension samples/tree@0.0.1
+[detector] Running generate for extension samples/vim@0.0.1
 ...
-[extender] Found build Dockerfile for extension 'samples/tree'
-[extender] Applying the Dockerfile at /layers/generated/build/samples_tree/Dockerfile...
+[extender] Found build Dockerfile for extension 'samples/vim'
+[extender] Applying the Dockerfile at /layers/generated/build/samples_vim/Dockerfile...
 ...
 [extender] Running build command
 [extender] ---> Hello Extensions Buildpack
-[extender] tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro
+[extender] vim v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro
 ...
 Successfully built image hello-extensions
 ```

--- a/content/docs/extension-guide/create-extension/build-dockerfile.md
+++ b/content/docs/extension-guide/create-extension/build-dockerfile.md
@@ -28,32 +28,14 @@ cat $PWD/samples/extensions/tree/bin/generate
 
 The extension generates a `build.Dockerfile` that installs `tree` on the builder image.
 
-### Re-create our builder with `hello-extensions` updated to require `tree`
-
-Edit `$PWD/samples/buildpacks/hello-extensions/bin/detect` to uncomment the first set of lines that output `[[requires]]` to the build plan:
-
-<!-- test:exec -->
-```bash
-sed -i "10,11s/#//" $PWD/samples/buildpacks/hello-extensions/bin/detect
-```
-
-(On Mac, use `sed -i '' "10,11s/#//" $PWD/samples/buildpacks/hello-extensions/bin/detect`)
-
-Re-create the builder:
-
-<!-- test:exec -->
-```
-pack builder create localhost:5000/extensions-builder \
-  --config $PWD/samples/builders/alpine/builder.toml \
-  --publish
-```
-
 ### Re-build the application image
 
 <!-- test:exec -->
 ```
 pack build hello-extensions \
   --builder localhost:5000/extensions-builder \
+  --env BP_EXT_DEMO=1 \
+  --env BP_REQUIRES=tree \
   --network host \
   --path $PWD/samples/apps/java-maven \
   --pull-policy always \

--- a/content/docs/extension-guide/create-extension/building-blocks-extension.md
+++ b/content/docs/extension-guide/create-extension/building-blocks-extension.md
@@ -12,7 +12,7 @@ aliases = [
 
 <!-- test:exec -->
 ```bash
-vim $PWD/samples/extensions/vim
+vim --help
 ```
 
 (That's right, we're using the very tool we will later be installing!) You should see something akin to the following:

--- a/content/docs/extension-guide/create-extension/building-blocks-extension.md
+++ b/content/docs/extension-guide/create-extension/building-blocks-extension.md
@@ -8,11 +8,11 @@ aliases = [
 
 <!-- test:suite=dockerfiles;weight=3 -->
 
-### Examine `tree` extension
+### Examine `vim` extension
 
 <!-- test:exec -->
 ```bash
-tree $PWD/samples/extensions/tree
+vim $PWD/samples/extensions/vim
 ```
 
 (That's right, we're using the very tool we will later be installing!) You should see something akin to the following:
@@ -44,7 +44,7 @@ tree $PWD/samples/extensions/tree
     the [spec](https://github.com/buildpacks/spec/blob/buildpack/main/image_extension.md)
     for further details.
 
-We'll take a closer look at the executables for the `tree` extension in the next step.
+We'll take a closer look at the executables for the `vim` extension in the next step.
 
 <!--+ if false+-->
 ---

--- a/content/docs/extension-guide/create-extension/run-dockerfile.md
+++ b/content/docs/extension-guide/create-extension/run-dockerfile.md
@@ -48,32 +48,14 @@ docker build \
   --tag run-image-curl .
 ```
 
-### Re-create our builder with `hello-extensions` updated to require `curl`
-
-Edit `$PWD/samples/buildpacks/hello-extensions/bin/detect` to uncomment the second set of lines that output `[[requires]]` to the build plan:
-
-<!-- test:exec -->
-```bash
-sed -i "14,15s/#//" $PWD/samples/buildpacks/hello-extensions/bin/detect
-```
-
-(On Mac, use `sed -i '' "14,15s/#//" $PWD/samples/buildpacks/hello-extensions/bin/detect`)
-
-Re-create the builder:
-
-<!-- test:exec -->
-```bash
-pack builder create localhost:5000/extensions-builder \
-  --config $PWD/samples/builders/alpine/builder.toml \
-  --publish
-```
-
 ### Re-build the application image
 
 <!-- test:exec -->
 ```bash
 pack build hello-extensions \
   --builder localhost:5000/extensions-builder \
+  --env BP_EXT_DEMO=1 \
+  --env BP_REQUIRES=tree,curl \
   --path $PWD/samples/apps/java-maven \
   --pull-policy always \
   --network host \

--- a/content/docs/extension-guide/create-extension/run-dockerfile.md
+++ b/content/docs/extension-guide/create-extension/run-dockerfile.md
@@ -45,7 +45,7 @@ Build the run image:
 ```bash
 docker build \
   --file $PWD/samples/stacks/alpine/run/curl.Dockerfile \
-  --tag run-image-curl .
+  --tag localhost:5000/run-image-curl .
 ```
 
 ### Re-build the application image
@@ -55,7 +55,7 @@ docker build \
 pack build hello-extensions \
   --builder localhost:5000/extensions-builder \
   --env BP_EXT_DEMO=1 \
-  --env BP_REQUIRES=tree,curl \
+  --env BP_REQUIRES=vim,curl \
   --path $PWD/samples/apps/java-maven \
   --pull-policy always \
   --network host \
@@ -68,26 +68,26 @@ You should see:
 
 ```
 [detector] ======== Results ========
-[detector] pass: samples/tree@0.0.1
+[detector] pass: samples/vim@0.0.1
 [detector] pass: samples/curl@0.0.1
 [detector] pass: samples/hello-extensions@0.0.1
 [detector] Resolving plan... (try #1)
-[detector] samples/tree             0.0.1
+[detector] samples/vim             0.0.1
 [detector] samples/curl             0.0.1
 [detector] samples/hello-extensions 0.0.1
-[detector] Running generate for extension samples/tree@0.0.1
+[detector] Running generate for extension samples/vim@0.0.1
 ...
 [detector] Running generate for extension samples/curl@0.0.1
 ...
 [detector] Checking for new run image
 [detector] Found a run.Dockerfile configuring image 'run-image-curl' from extension with id 'samples/curl'
 ...
-[extender] Found build Dockerfile for extension 'samples/tree'
-[extender] Applying the Dockerfile at /layers/generated/build/samples_tree/Dockerfile...
+[extender] Found build Dockerfile for extension 'samples/vim'
+[extender] Applying the Dockerfile at /layers/generated/build/samples_vim/Dockerfile...
 ...
 [extender] Running build command
 [extender] ---> Hello Extensions Buildpack
-[extender] tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro
+[extender] vim v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro
 ...
 Successfully built image hello-extensions
 ```
@@ -105,16 +105,16 @@ You should see something akin to:
 curl 7.85.0-DEV (x86_64-pc-linux-musl) ... more stuff here ...
 ```
 
-What happened: now that `hello-extensions` requires both `tree` and `curl` in its build plan, both extensions are
+What happened: now that `hello-extensions` requires both `vim` and `curl` in its build plan, both extensions are
   included in the build and provide the needed dependencies for build and launch, respectively
-* The `tree` extension installs `tree` at build time, as before
+* The `vim` extension installs `vim` at build time, as before
 * The `curl` extension switches the run image to `run-image-curl`, which has `curl` installed
 
 Now our `curl` process can succeed!
 
 ## What's next?
 
-The `tree` and `curl` examples are very simple, but we can unlock powerful new features with this functionality.
+The `vim` and `curl` examples are very simple, but we can unlock powerful new features with this functionality.
 
 Platforms could have several run images available, each tailored to a specific language family, thus limiting the number
 of installed dependencies for each image to the minimum necessary to support the targeted language. Image extensions

--- a/content/docs/extension-guide/create-extension/why-dockerfiles.md
+++ b/content/docs/extension-guide/create-extension/why-dockerfiles.md
@@ -60,6 +60,7 @@ Run `pack build` (note that the "source" directory is effectively ignored in our
 ```
 pack build hello-extensions \
   --builder localhost:5000/extensions-builder \
+  --env BP_EXT_DEMO=1 \
   --network host \
   --path $PWD/samples/apps/java-maven \
   --pull-policy always \

--- a/katacoda/scenarios/buildpack-author-guide/adding-bill-of-materials.md
+++ b/katacoda/scenarios/buildpack-author-guide/adding-bill-of-materials.md
@@ -17,10 +17,11 @@ pack inspect-image test-ruby-app
 ```{{execute}}
 You should see the following:
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```text
 Run Images:
   cnbs/sample-stack-run:jammy
+...
 
 Buildpacks:
   ID                   VERSION        HOMEPAGE

--- a/katacoda/scenarios/buildpack-author-guide/building-blocks-cnb.md
+++ b/katacoda/scenarios/buildpack-author-guide/building-blocks-cnb.md
@@ -109,10 +109,12 @@ The `pack build` command takes in your Ruby sample app as the `--path` argument 
 
 After running the command, you should see that it failed to detect, as the `detect` script is currently written to simply error out.
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```
 ===> DETECTING
+...
 err:  examples/ruby@0.0.1 (1)
+...
 ERROR: No buildpack groups passed detection.
 ERROR: failed to detect: buildpack(s) failed with err
 ```

--- a/katacoda/scenarios/buildpack-author-guide/caching.md
+++ b/katacoda/scenarios/buildpack-author-guide/caching.md
@@ -251,6 +251,7 @@ it will download the gems:
 <!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby
 ---> Installing gems
@@ -268,6 +269,7 @@ you will see the new caching logic at work during the `BUILDING` phase:
 <!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby
 ---> Reusing gems

--- a/katacoda/scenarios/buildpack-author-guide/make-buildpack-configurable.md
+++ b/katacoda/scenarios/buildpack-author-guide/make-buildpack-configurable.md
@@ -122,9 +122,10 @@ pack build test-ruby-app --path ./ruby-sample-app --buildpack ./ruby-buildpack
 
 You will notice that version of Ruby specified in the app's `.ruby-version` file is downloaded.
 
-<!-- test:assert=contains -->
+<!-- test:assert=contains;ignore-lines=... -->
 ```text
 ===> BUILDING
+...
 ---> Ruby Buildpack
 ---> Downloading and extracting Ruby 3.1.0
 ```


### PR DESCRIPTION
We don't need to re-create the builder, we just need to update the env vars passed to the buildpack to make it require things from extensions.

I wanted to make this fix as part of https://github.com/buildpacks/docs/pull/581, but that PR is blocked on there being new versions of pack and the lifecycle.