### PR TITLE
Use pre-release version of pack for docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pack
         uses: buildpacks/github-actions/setup-pack@v5.2.0
         with:
-          pack-version: '0.28.0'
+          pack-version: '0.30.0-pre3'
       - name: Test
         run: make test
         env:


### PR DESCRIPTION
Use the latest pre-release of pack so that we can build images that use extensions API