### PR TITLE
Patch 1 -Fixed Issue in building-blocks-cnb.md 

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -91,7 +91,7 @@ These two files are executable `detect` and `build` scripts. You are now able to
 
 ### Using your buildpack with `pack`
 
-In order to test your buildpack, you will need to run the buildpack against your sample Ruby app using the `pack` CLI.
+In order to test your buildpack, you will need to run the buildpack against your sample Node.js app using the `pack` CLI.
 
 Set your default [builder][builder] by running the following:
 

--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -117,7 +117,7 @@ pack build test-node-js-app --path ./node-js-sample-app --buildpack ./node-js-bu
 ```
 <!--+- "{{execute}}"+-->
 
-The `pack build` command takes in your Ruby sample app as the `--path` argument and your buildpack as the `--buildpack` argument.
+The `pack build` command takes in your Node.js sample app as the `--path` argument and your buildpack as the `--buildpack` argument.
 
 After running the command, you should see that it failed to detect, as the `detect` script is currently written to simply error out.
 


### PR DESCRIPTION
Update documentation: replace 'Ruby' with 'Node.js'

Changed the word 'Ruby' to 'Node.js' in the documentation to correct an inaccuracy with the previous content.