### PR TITLE
Generate older aliases to `pack` documentation

### DIFF
--- a/tools/get_pack_commands.go
+++ b/tools/get_pack_commands.go
@@ -22,6 +22,7 @@ const (
 	gendocFrontmatterTemplate = `+++
 title="%s"
 no_edit="true"
+aliases=[ "/docs/tools/pack" ]
 +++
 <!--more-->
 `
@@ -30,7 +31,8 @@ no_edit="true"
 var filePrepender = func(filename string) string {
 	name := filepath.Base(filename)
 	name = strings.Replace(name, ".md", "", -1)
-	return fmt.Sprintf(gendocFrontmatterTemplate, strings.Replace(name, "_", " ", -1))
+	presentationName := strings.Replace(name, "_", " ", -1)
+	return fmt.Sprintf(gendocFrontmatterTemplate, presentationName)
 }
 
 var linkHandler = func(name string) string {
@@ -52,7 +54,7 @@ func main() {
 	}
 
 	if _, err := os.Stat(filepath.Join(outputPath, indexFile)); os.IsNotExist(err) {
-		if err := ioutil.WriteFile(filepath.Join(outputPath, indexFile), []byte(filePrepender("Pack CLI")), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(outputPath, indexFile), []byte(filePrepender("Pack CLI")), os.ModePerm); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
When generating the pack cli docs, create aliases
using the older document structure