### PR TITLE
Update project description on front page

### DIFF
--- a/themes/buildpacks/layouts/index.html
+++ b/themes/buildpacks/layouts/index.html
@@ -90,7 +90,18 @@
     <a href="/features">See list of features</a>
   </div>
 
-  <h2>About the Project</h2>
+  <h2>What We Do</h2>
+  <section class="row">
+    <div class="col-sm">
+      <p>Cloud Native Buildpacks (CNBs) transform your application source code into container images that can run on any
+        cloud. With buildpacks, organizations can concentrate the knowledge of container build best practices within a
+        specialized team, instead of having application developers across the organization individually maintain their
+        own Dockerfiles. This makes it easier to know what is inside application images, enforce security and compliance
+        requirements, and perform upgrades with minimal effort and intervention.</p>
+    </div>
+  </section>
+
+  <h2>Our Origin Story</h2>
   <section class="row">
     <div class="col-sm">
       <p><strong>Buildpacks</strong> were first conceived by Heroku in 2011. Since then, they have been adopted by Cloud
@@ -110,8 +121,8 @@
       <p>Cloud Native Buildpacks embrace modern container standards, such as the OCI image format. They take advantage
         of the latest capabilities of these standards, such as cross-repository blob mounting and image layer "rebasing"
         on Docker API v2 registries.</p>
-    </div>
-  </section>
+      </div>
+    </section>
 </div>
 
 <div id="get-started" class="container">


### PR DESCRIPTION
We have developed a succinct description of what the project does. Include this on the front page before our claims about our heritage.