### PR TITLE
Fix summaries for "custom env" page and add link to podman from main …

### DIFF
--- a/content/docs/app-journey.md
+++ b/content/docs/app-journey.md
@@ -8,11 +8,12 @@ getting-started=true
 
 In this tutorial, we'll explain how to use `pack` and **buildpacks** to create a runnable app image from source code.
 
-In order to run the build process in an isolated fashion, `pack` uses **Docker**. That means you'll need to make sure you have both `docker` and `pack` installed:
-
-{{< download-button href="https://store.docker.com/search?type=edition&offering=community" color="blue" >}} Install Docker {{</>}}
+In order to run the build process in an isolated fashion, `pack` uses **Docker** or a Docker-compatible daemon to create the containers where buildpacks execute.
+That means you'll need to make sure you have both `pack` and a daemon installed:
 
 {{< download-button href="/docs/install-pack" color="pink" >}} Install pack {{</>}}
+
+{{< download-button href="https://store.docker.com/search?type=edition&offering=community" color="blue" >}} Install Docker {{</>}} or alternatively, see [this page](/docs/for-app-developers/how-to/special-cases/build-on-podman) about working with `podman`.
 
 > **NOTE:** `pack` is only one implementation of the [Cloud Native Buildpacks Platform Specification][cnb-platform-spec]. Additionally, not all Cloud Native Buildpacks Platforms require Docker.
 

--- a/content/docs/for-app-developers/how-to/special-cases/_index.md
+++ b/content/docs/for-app-developers/how-to/special-cases/_index.md
@@ -1,6 +1,5 @@
 +++
 title="Build in custom environments"
 weight=3
-
 include_summaries=true
 +++

--- a/content/docs/for-app-developers/how-to/special-cases/build-for-windows.md
+++ b/content/docs/for-app-developers/how-to/special-cases/build-for-windows.md
@@ -7,6 +7,11 @@ aliases=[
 weight=2
 +++
 
+You can use buildpacks to build container images that run Windows containers on Windows (WCOW).
+
+This page is not relevant if your host machine is Windows but you are running Linux containers on Windows (LCOW);
+in this case, no special configuration is required.
+
 <!--more-->
 
 > **EXPERIMENTAL** Windows support is experimental!

--- a/content/docs/for-app-developers/how-to/special-cases/export-to-oci-layout.md
+++ b/content/docs/for-app-developers/how-to/special-cases/export-to-oci-layout.md
@@ -5,6 +5,7 @@ aliases=[
   "/docs/features/experimental/export-to-oci-layout"
 ]
 weight=3
+summary="The OCI Image Layout is the directory structure for OCI content-addressable blobs and location-addressable references."
 +++
 
 <!--more-->


### PR DESCRIPTION
…tutorial

I re-worded the main tutorial to indicate that podman is an alternative to docker

Also in looking into this, I noticed that the summary page for "build in custom environments" looked a little off, see before and after:

![Screenshot 2024-04-04 at 11 04 10 AM](https://github.com/buildpacks/docs/assets/6894483/d4f81a1a-889a-49ae-9c1b-5a7034f89ec0)

![Screenshot 2024-04-04 at 11 04 44 AM](https://github.com/buildpacks/docs/assets/6894483/1347b304-2f5d-4086-82e5-868eb45022b3)
