### PR TITLE
removed other ics calendars

### DIFF
--- a/data/calendar.yml
+++ b/data/calendar.yml
@@ -7,15 +7,6 @@ subcalendars:
   #   - id: teamup id
   #   - name: human readable name
   #   - color: html color of events on calendar
-  - id: 10287223
-    name: Community
-    color: '#4aaace'
-  - id: 9330130
-    name: Office Hours
-    color: '#2951b9'
-  - id: 9046533
-    name: Sub-Team Syncs
-    color: '#542382'
   - id: 9046534
     name: Working Group
     color: '#d96fbf'


### PR DESCRIPTION
Removed community, office hours, and team leads ics calendar buttons since those do not contain anything to download (right now).