### PR TITLE
Fix edit links for buildpacks documentation

### DIFF
--- a/themes/buildpacks/layouts/partials/support.html
+++ b/themes/buildpacks/layouts/partials/support.html
@@ -8,8 +8,8 @@
     {{ if .Params.no_edit }}
     {{ else }}
     {{ $editQuery := (querify "description" "Signed-off-by: NAME <EMAIL_ADDRESS>\n\n> _By signing off you acknowledge adhering to the requirements listed here: https://probot.github.io/apps/dco/_") }}
-    <a href="{{ $.Site.Params.github_base_url }}/docs/edit/main/content/{{ with .File }}{{ .Path }}{{ end }}?{{ $editQuery | safeURL }}"
-       class="button-light button-small icon-button github-button bg-white inline-flex" target="_blank">Edit</a>
+      <a href="https://github.com/buildpacks/docs/edit/main/content/docs/_index.md?description=Signed-off-by%3A&#43;NAME&#43;%3CEMAIL_ADDRESS%3E%0A%0A%3E&#43;_By&#43;signing&#43;off&#43;you&#43;acknowledge&#43;adhering&#43;to&#43;the&#43;requirements&#43;listed&#43;here%3A&#43;https%3A%2F%2Fprobot.github.io%2Fapps%2Fdco%2F_"
+      class="button-light button-small icon-button github-button bg-white inline-flex" target="_blank">Edit</a>
     {{ end }}
   {{ end }}
 </div>


### PR DESCRIPTION
The edit links for the documentation pages were redirecting to non-existent file paths, resulting in a File not found error. This commit corrects the edit links to point to the correct file paths, allowing contributors to edit the documentation pages for buildpacks directly from the website.
#694 