### PR TITLE
update to run the `pack` command

### DIFF
--- a/content/docs/for-buildpack-authors/tutorials/basic-buildpack/02_building-blocks-cnb.md
+++ b/content/docs/for-buildpack-authors/tutorials/basic-buildpack/02_building-blocks-cnb.md
@@ -113,7 +113,7 @@ pack config trusted-builders add cnbs/sample-builder:jammy
 ```
 <!--+- "{{execute}}"+-->
 
-Then run the following `pack` command after `cd` to `node-js-sample-app`:
+Then run the following `pack` command from the `node-js-sample-app` directory:
 
 <!-- test:exec;exit-code=1 -->
 ```bash

--- a/content/docs/for-buildpack-authors/tutorials/basic-buildpack/02_building-blocks-cnb.md
+++ b/content/docs/for-buildpack-authors/tutorials/basic-buildpack/02_building-blocks-cnb.md
@@ -113,11 +113,11 @@ pack config trusted-builders add cnbs/sample-builder:jammy
 ```
 <!--+- "{{execute}}"+-->
 
-Then run the following `pack` command:
+Then run the following `pack` command after `cd` to `node-js-sample-app`:
 
 <!-- test:exec;exit-code=1 -->
 ```bash
-pack build test-node-js-app --path ./node-js-sample-app --buildpack ./node-js-buildpack
+pack build test-node-js-app --path ./ --buildpack ./node-js-buildpack
 ```
 <!--+- "{{execute}}"+-->
 


### PR DESCRIPTION
The previous command is not runnable as the location of the command is important.

Alternative when outside the `node-js-sample-app` directory:
```bash
pack build test-node-js-app --path ./node-js-sample-app --buildpack ./node-js-sample-app/node-js-buildpack
```