### PR TITLE
WIP: move talks to a new page #712

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -69,7 +69,7 @@ If you didn't find anything you'd like to improve while going through the tutori
 
 > Depending our your depth of understanding or desires some components may be more ideal than others.
 
-[talks]: /docs/#talks
+[talks]: /docs/talks
 [tutorials]: /docs/#tutorials
 [spec]: /docs/reference/spec/
 [platforms]: /docs/for-app-developers/concepts/platform/

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,9 +4,9 @@ weight=1
 summary="Get started with Cloud Native Buildpacks."
 +++
 
-## Talks
+## Overview
 
-{{< talks >}}
+Cloud Native Buildpacks (CNBs) transform your application source code into [container images](https://github.com/opencontainers/image-spec/blob/main/spec.md) that can run on any cloud. With buildpacks, organizations can concentrate the knowledge of container build best practices within a specialized team, instead of having application developers across the organization individually maintain their own Dockerfiles. This makes it easier to know what is inside application images, enforce security and compliance requirements, and perform upgrades with minimal effort and intervention. The CNB project was initiated by Pivotal and Heroku in January 2018 and joined the Cloud Native Computing Foundation (CNCF) as an Apache-2.0 licensed project in October 2018. It is currently an incubating project within the CNCF.
 
 ---
 
@@ -19,9 +19,9 @@ summary="Get started with Cloud Native Buildpacks."
 
 See how-to guides, concepts, and tutorials tailored to specific personas:
 
-*  [App Developers](/docs/for-app-developers/)
-*  [Buildpack Authors](/docs/for-buildpack-authors/)
-*  [Operators](/docs/for-platform-operators/)
+* [App Developers](/docs/for-app-developers/)
+* [Buildpack Authors](/docs/for-buildpack-authors/)
+* [Operators](/docs/for-platform-operators/)
 
 ## [Tools](/docs/for-platform-operators/)
 
@@ -40,18 +40,18 @@ Reference documents for various key aspects of the project.
 
 ---
 
-# Community and Support
+## Community and Support
 
 Cloud Native Buildpacks is an incubating project in the CNCF. We welcome contribution from the community. Here you will find helpful information for interacting with the core team and contributing to the project.
 
-## Community
+### Community
 
 The best place to contact the Cloud Native Buildpack team is on the [CNCF Slack](https://slack.cncf.io/) in the #buildpacks or [mailing list](https://lists.cncf.io/g/cncf-buildpacks).
 
-## Contributor's Guide
+### Contributor's Guide
 
 Find out the various ways that _you_ can contribute to the Cloud Native Buildpacks project using our [contributor's guide](https://github.com/buildpacks/community/blob/main/contributors/guide.md).
 
-## Project Roadmap
+### Project Roadmap
 
 This is a community driven project and our roadmap is publicly available on our [Github page](https://github.com/buildpacks/community/blob/main/ROADMAP.md). We encourage you to contribute with feature requests.

--- a/content/docs/talks.md
+++ b/content/docs/talks.md
@@ -1,0 +1,23 @@
++++
+title="Talks"
+weight=2
+getting-started=true
++++
+
+## Talks
+
+We love talks to share the latest development updates, covering Buildpacks basics and more, receive feedback and questions, and get to know other members of the community.
+
+### Introductory Talks  
+
+If you are new to the project, you can watch some of introductory talks on [Cloud Native Buildpacks' YouTube channel](https://www.youtube.com/@buildpacks)
+
+### Conference Talks
+
+{{< talks >}}
+
+More conference talks are available under the [Conference Talks Playlist](https://www.youtube.com/playlist?list=PL1p8pquzNvRqz3v7Q-OA7wldIxLCNFHcC) on YouTube.  
+
+### Working Group Meetings
+
+Feel free to look through the archive of previous community meetings on our [Working Group YouTube Playlist](https://www.youtube.com/playlist?list=PL1p8pquzNvRpDbbgZ0db0MRA-W5_w0G1U)

--- a/data/talks.yml
+++ b/data/talks.yml
@@ -1,7 +1,7 @@
 # - name (required): Name of video
 #   description: Short video description
 #   event_name: Name of the event
-#   preseters: Presenters of talk
+#   presenters: Presenters of talk
 #      - Name, Employer
 #   youtube_id (required): URL to video
 #   year (required): Year recorded
@@ -78,25 +78,6 @@
     - name: Slides
       icon: file-powerpoint
       url: https://docs.google.com/presentation/d/1Ejo8Mf7GXxVHL7PjiApCZMJLtbX6VO8n2H7vEcZkV0I/view
-- name: "Pack to the Future: Cloud-Native Buildpacks on k8s"
-  presenters:
-    - Emily Casey, Pivotal
-    - Joe Kutner, Heroku
-  description: >-
-    Are you a developer that would rather build features than maintain Dockerfiles? Is your organization
-    excited about Kubernetes but worried about patching vulnerable dependencies across a great number of
-    containers? In this talk, you’ll learn how to use the pack CLI to go from source to image in seconds
-    and patch a pod even faster. Cloud Foundry and Heroku users have long appreciated the developer
-    experience and security guarantees provided by buildpacks. Cloud-Native Buildpacks (a CNCF sandbox
-    project) represents a generational leap in buildpacks, bringing the power of buildpacks to k8s and
-    beyond.
-  event_name: SpringOne Platform
-  youtube_id: J2SXkmOo8iQ
-  year: 2019
-  resources:
-    - name: Slides
-      icon: file-powerpoint
-      url: https://docs.google.com/presentation/d/14rkLA2hn3nVu_liiW6Y7hy3hSsnz1HueEdLkhvChONM/view
 - name: "Production CI/CD w/CNBs: Tekton, Gitlab & CircleCI(plus), Oh My!"
   presenters:
     - David Freilich, VMware
@@ -146,3 +127,22 @@
     - name: Slides
       icon: file-powerpoint
       url: https://slides.com/danielleadams/cnbs-node-js-interactive-19
+- name: "Pack to the Future: Cloud-Native Buildpacks on k8s"
+  presenters:
+    - Emily Casey, Pivotal
+    - Joe Kutner, Heroku
+  description: >-
+    Are you a developer that would rather build features than maintain Dockerfiles? Is your organization
+    excited about Kubernetes but worried about patching vulnerable dependencies across a great number of
+    containers? In this talk, you’ll learn how to use the pack CLI to go from source to image in seconds
+    and patch a pod even faster. Cloud Foundry and Heroku users have long appreciated the developer
+    experience and security guarantees provided by buildpacks. Cloud-Native Buildpacks (a CNCF sandbox
+    project) represents a generational leap in buildpacks, bringing the power of buildpacks to k8s and
+    beyond.
+  event_name: SpringOne Platform
+  youtube_id: J2SXkmOo8iQ
+  year: 2019
+  resources:
+    - name: Slides
+      icon: file-powerpoint
+      url: https://docs.google.com/presentation/d/14rkLA2hn3nVu_liiW6Y7hy3hSsnz1HueEdLkhvChONM/view


### PR DESCRIPTION
   * Adds a new talks page
   * Changes the order of talks by time (Desc)
   * Removes the talks section from the Getting Started landing page
   * Adds an overview paragraph to the Getting Started landing page
   * Updates the level of few section headings in the Getting Started landing page
   * Other minor edits

Closes #712 