### PR TITLE
Fix references to "meta buildpack"

### DIFF
--- a/content/docs/.common/concepts/composite-buildpack.md
+++ b/content/docs/.common/concepts/composite-buildpack.md
@@ -3,7 +3,7 @@ title="What is a composite buildpack?"
 weight=99
 +++
 
-A composite buildpack, also sometimes called a "meta-buildpack",
+A composite buildpack, also sometimes called a "meta buildpack",
 is a buildpack that does not contain any `./bin/detect` or `./bin/build` binaries,
 but instead references other buildpacks in its `buildpack.toml` via the `[[order]]` array.
 

--- a/content/docs/for-buildpack-authors/concepts/buildpack-group.md
+++ b/content/docs/for-buildpack-authors/concepts/buildpack-group.md
@@ -15,26 +15,27 @@ Buildpack groups allow you to connect multiple modular buildpacks together, maki
 
 For example, you might have a buildpack that installs Java and a buildpack that uses Maven to build your application. These two buildpacks can be combined into a group to implement higher-level functionality, specifically that the first one will install Java and the second will use Java to run Maven, which is a Java build tool.
 
-Because you can have many buildpack groups in a [builder][builder] or [meta-buildpack][meta-buildpack] and you can reuse buildpacks, you could have a second buildpack group that reuses the buildpack to provide Java but uses a third buildpack that provides Gradle to build your application. By doing this, you can create additional high-level functionality without having duplication.
+Because you can have many buildpack groups in a [builder][builder] or [composite buildpack][composite buildpack] (sometimes referred to as a "meta buildpack"),
+and you can reuse buildpacks, you could have a second buildpack group that reuses the buildpack to provide Java but uses a third buildpack that provides Gradle to build your application. By doing this, you can create additional high-level functionality without having duplication.
 
 ## Anatomy of a buildpack group
 
 A [buildpack group][buildpack-group] is a list of buildpack entries defined in the order in which they will run.
 
-A buildpack entry is identified by an id and a version. It may also be marked as optional. While you may have one or more buildpacks in a buildpack group, you may have one or more buildpack groups in a builder or meta-buildpack.
+A buildpack entry is identified by an id and a version. It may also be marked as optional. While you may have one or more buildpacks in a buildpack group, you may have one or more buildpack groups in a builder or composite buildpack.
 
 ## Detection with buildpack groups
 
-A [builder][builder] or [meta-buildpack][meta-buildpack] may contain multiple buildpack groups. When the lifecycle executes the detection process, it will process each buildpack group it finds in the order that the groups are specified. For each buildpack group, the lifecycle will execute the detect phase of all buildpacks in that group (these can be executed in parallel) and aggregate the results. The lifecycle will select the first buildpack group by order where all of the non-optional buildpacks in that group pass detection.
+A [builder][builder] or [composite buildpack][composite buildpack] may contain multiple buildpack groups. When the lifecycle executes the detection process, it will process each buildpack group it finds in the order that the groups are specified. For each buildpack group, the lifecycle will execute the detect phase of all buildpacks in that group (these can be executed in parallel) and aggregate the results. The lifecycle will select the first buildpack group by order where all of the non-optional buildpacks in that group pass detection.
 
 For example, if a builder has buildpack groups A, B and C. The lifecycle will run detection against A. If all of the non-optional buildpacks in that group pass detection, then it will select A. In that case, B and C will not be processed. If A has any failing non-optional buildpacks, then the lifecycle will move on to process buildpack group B. If B has any failing non-optional buildpacks, then the lifecycle will move on to process buildpack group C. If C fails, then the entire detection process will fail.
 
-If a buildpack group contains meta-buildpacks, which in turn may contain more buildpack groups those are expanded using [the order resolution rules][order-resolution] such that each buildpack group in the meta-buildpack is tried with the other buildpacks in the containing buildpack group.
+If a buildpack group contains composite buildpacks, which in turn may contain more buildpack groups those are expanded using [the order resolution rules][order-resolution] such that each buildpack group in the composite buildpack is tried with the other buildpacks in the containing buildpack group.
 
 For example:
 
 - the builder has a buildpack group A that contains buildpacks X, Y and Z
-- Y is a meta-buildpack containing buildpack groups B and C
+- Y is a composite buildpack containing buildpack groups B and C
 - buildpack group B contains buildpacks T and U
 - buildpack group C contains buildpacks V and W
 
@@ -43,7 +44,7 @@ The lifecycle will expand this into the following buildpack groups:
 - X, T, U, Z
 - X, V, W, Z
 
-Y is not included because meta-buildpacks only provide groups, they do not participate in the build process or contain build/detect binaries.
+Y is not included because composite buildpacks only provide groups, they do not participate in the build process or contain build/detect binaries.
 
 The [order resolution rules in the buildpacks spec][order-resolution] contains additional examples that illustrate more complex scenarios.
 
@@ -57,4 +58,4 @@ The [Operator's Guide][operator-guide] has more information on creating builders
 [order-resolution]: https://github.com/buildpacks/spec/blob/main/buildpack.md#order-resolution
 [operator-guide]: /docs/for-platform-operators/
 [builder]: /docs/for-platform-operators/concepts/builder/
-[meta-buildpack]: /docs/for-platform-operators/concepts/composite-buildpack
+[composite buildpack]: /docs/for-platform-operators/concepts/composite-buildpack

--- a/content/docs/for-buildpack-authors/concepts/lifecycle-phases.md
+++ b/content/docs/for-buildpack-authors/concepts/lifecycle-phases.md
@@ -19,7 +19,7 @@ In the example we run `pack` on the NodeJS application to produce an application
 
 ## NodeJS buildpack
 
-The example NodeJS buildpack is a meta-buildpack.  It is composed of
+The example NodeJS buildpack is a composite buildpack (sometimes referred to as a "meta buildpack").  It is composed of
 
 * `node-engine` buildpack that provides the `node` and `npm` binaries,
 * `yarn` buildpack that provides the `yarn` binary,
@@ -27,7 +27,7 @@ The example NodeJS buildpack is a meta-buildpack.  It is composed of
 * `yarn-start` and `npm-start` buildpacks that configure the entrypoint to the application image,
 * `procfile` a buildpack that allows developers to provide a [Heroku-style](https://devcenter.heroku.com/articles/procfile#procfile-format) entrypoint for the image.
 
-The `nodejs` buildpack itself is a meta-buildpack which defines two **order groups**.  Here we represent the order groups visually:
+The `nodejs` buildpack itself is a composite buildpack which defines two **order groups**.  Here we represent the order groups visually:
 
 ![nodejs order groups](/images/order-groups.svg)
 
@@ -79,7 +79,7 @@ The dependencies are provided using the mechanism an NodeJS developer expects.  
 
 Finally, we describe the container entrypoint using a script in the `package.json`.  The script must be named `start` according to NodeJS convention.   Here we see that the entrypoint should run the provided `node index.js` command.
 
-We build our application using the default builder and specify to only use the `nodejs` meta-buildpack in the build.  The restriction to use only the `nodejs` meta-buildpack simplifies the explanation as that buildpack provides only two order groups.
+We build our application using the default builder and specify to only use the `nodejs` composite buildpack in the build.  The restriction to use only the `nodejs` composite buildpack simplifies the explanation as that buildpack provides only two order groups.
 
 <asciinema-player
   idle-time-limit="0.5s"
@@ -388,4 +388,4 @@ Our NodeJS example image requires an entrypoint called `web`.  The `web` entrypo
 
 ## Summary
 
-We have taken a detailed look at how buildpacks are used to build a sample application.  The meta-buildpack contains two order groups and we have seen examples of how an order group is resolved.  In addition we have looked at the contributions that a buildpack makes to the build plan and considered how these are resolved into a buildpack plan to be provided to the build phase of specific buildpacks.  Finally, we have briefly considered how the analyze and restore phases can allow advanced caching strategies.
+We have taken a detailed look at how buildpacks are used to build a sample application.  The composite buildpack contains two order groups and we have seen examples of how an order group is resolved.  In addition we have looked at the contributions that a buildpack makes to the build plan and considered how these are resolved into a buildpack plan to be provided to the build phase of specific buildpacks.  Finally, we have briefly considered how the analyze and restore phases can allow advanced caching strategies.

--- a/content/docs/reference/config/buildpack-config.md
+++ b/content/docs/reference/config/buildpack-config.md
@@ -88,7 +88,7 @@ The schema is as follows:
     A list of mixins required on the stack images.
 
 - **`order`** _(list, optional)_\
-  A list of buildpack groups for the purpose of creating a [meta-buildpack][meta-buildpack]. This list determines the
+  A list of buildpack groups for the purpose of creating a [composite buildpack][composite buildpack] (sometimes referred to as a "meta buildpack"). This list determines the
   order in which groups of buildpacks will be tested during detection. _If omitted, `targets` or `stacks` list must be present.
   Cannot be used in conjunction with `targets` or `stacks` list._
 
@@ -110,3 +110,4 @@ The schema is as follows:
 
 [buildpack]: /docs/for-buildpack-authors/concepts/buildpack
 [lifecycle]: /docs/for-buildpack-authors/concepts/lifecycle-phases
+[composite buildpack]: /docs/for-platform-operators/concepts/composite-buildpack

--- a/content/docs/reference/config/package-config.md
+++ b/content/docs/reference/config/package-config.md
@@ -19,7 +19,7 @@ The schema is as follows:
     A URL or path to an [archive][supported-archives], or a path to a directory. If path is relative, it must be relative to the `package.toml`.
 
 - #### `dependencies` _(list, optional)_
-  A set of dependent buildpack locations, for packaging a meta-buildpack. Each dependent buildpack location must correspond to an [order group][order-group] within the meta-buildpack being packaged, and must have **one** of the following fields:
+  A set of dependent buildpack locations, for packaging a composite buildpack (sometimes referred to as a "meta buildpack"). Each dependent buildpack location must correspond to an [order group][order-group] within the composite buildpack being packaged, and must have **one** of the following fields:
 
   - **`uri`** _(string)_\
     A URL or path to an [archive][supported-archives], a packaged buildpack (saved as a `.cnb` file), or a directory. If path is relative, it must be relative to the `package.toml`.


### PR DESCRIPTION
It should be called a "composite buildpack" but we can refer to the old name too