### PR TITLE
Update ARM build docs

### DIFF
--- a/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
+++ b/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
@@ -10,7 +10,7 @@ weight=1
 <!--more-->
 
 Building for the ARM architecture is now easier than ever! The `heroku/builder:24` builder supports both AMD64 and ARM64 architectures, and includes
-multi-arch Go, Java, Node.js, Python, Ruby and Scala buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
+multi-arch Go, Java, Node.js, PHP, Python, Ruby and Scala buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
 
 ### 1. Clone the [samples][samples] repository
 

--- a/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
+++ b/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
@@ -10,7 +10,7 @@ weight=1
 <!--more-->
 
 Building for the ARM architecture is now easier than ever! The `heroku/builder:24` builder supports both AMD64 and ARM64 architectures, and includes
-multi-arch Java, Node.js, Python, Ruby, Scala and Go buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
+multi-arch Go, Java, Node.js, Python, Ruby and Scala buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
 
 ### 1. Clone the [samples][samples] repository
 
@@ -22,17 +22,17 @@ git clone https://github.com/buildpacks/samples
 
 ### 2. Build the app
 
-If you're using an ARM64 computer (such as an Apple Silicon Mac, or an AWS Graviton instance), you can produce an ARM64 OCI image with [pack][pack] simply by setting your builder to `heroku/builder:24`:
+If you're using an ARM64 computer (such as an Apple Silicon Mac, or an AWS Graviton instance), you can build an ARM64 OCI image with [pack][pack] simply by setting your builder to `heroku/builder:24`:
 ```
 pack build java-maven-sample --path samples/apps/java-maven/ --builder heroku/builder:24
 ```
 <!--+- "{{execute}}"+-->
 
-As `heroku/builder:24` is a multi-arch builder, it'll default to the current architecture, and an AMD64 image will be built when running `pack` on that architecture.
+By default, `pack` uses the current architecture for multi-arch builders like `heroku/builder:24`, so an AMD64 image will be built on AMD64 systems.
 
-If you want to build an ARM64 image from a different host architecture, you can use the arch-specific builder tag: `heroku/builder:24_linux-arm64`:
+If you want to build an ARM64 image from a different host architecture, use the `--platform` parameter:
 ```
-pack build java-maven-sample --path samples/apps/java-maven/ --builder heroku/builder:24_linux-arm64
+pack build java-maven-sample --path samples/apps/java-maven/ --builder heroku/builder:24 --platform linux/arm64
 ```
 <!--+- "{{execute}}"+-->
 


### PR DESCRIPTION
Updating the ARM build docs to reflect [`pack build --platform`](https://github.com/buildpacks/pack/pull/2162) support introduced in [`pack v0.34.0`](https://github.com/buildpacks/pack/releases/tag/v0.34.0).