### PR TITLE
fix build-base example

### DIFF
--- a/content/docs/for-platform-operators/how-to/build-inputs/create-builder/build-base.md
+++ b/content/docs/for-platform-operators/how-to/build-inputs/create-builder/build-base.md
@@ -22,7 +22,7 @@ FROM ubuntu:jammy
 # Install packages that we want to make available at build time
 RUN apt-get update && \
   apt-get install -y xz-utils ca-certificates && \
-  rm -rf /var/lib/apt/lists/* \
+  rm -rf /var/lib/apt/lists/*
 
 # Set required CNB user information
 ARG cnb_uid=1000
@@ -32,7 +32,7 @@ ENV CNB_GROUP_ID=${cnb_gid}
 
 # Create user and group
 RUN groupadd cnb --gid ${CNB_GROUP_ID} && \
-  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb \
+  useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
 
 # Set user and group
 USER ${CNB_USER_ID}:${CNB_GROUP_ID}


### PR DESCRIPTION
These extra slashes result in lines being unintentionally appended to previous `RUN` statements. This breaks the image build.

Removing them gives us the desired behavior.