### PR TITLE
Document builder property available in project descriptor

### DIFF
--- a/content/docs/for-app-developers/how-to/build-inputs/use-project-toml.md
+++ b/content/docs/for-app-developers/how-to/build-inputs/use-project-toml.md
@@ -107,6 +107,21 @@ pack build sample-app \
 docker run sample-app
 ```
 
+### Specify Builder
+The builder can also be [specified](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md#iobuildpacksbuilder-optional) in `project.toml`.
+
+```toml
+[io.buildpacks.builder]
+builder = "cnbs/sample-builder:jammy"
+```
+
+```shell script
+# then the pack command does not require builder to be set
+pack build sample-app \
+    --path  samples/apps/bash-script/
+```
+
+
 ### Further Reading
 For more about project descriptors, look at the [schema][descriptor-schema], as well as the [specification][spec].
 

--- a/content/docs/for-app-developers/how-to/build-inputs/use-project-toml.md
+++ b/content/docs/for-app-developers/how-to/build-inputs/use-project-toml.md
@@ -111,7 +111,7 @@ docker run sample-app
 The builder can also be [specified](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md#iobuildpacksbuilder-optional) in `project.toml`.
 
 ```toml
-[io.buildpacks.builder]
+[io.buildpacks]
 builder = "cnbs/sample-builder:jammy"
 ```
 

--- a/content/docs/reference/config/project-descriptor.md
+++ b/content/docs/reference/config/project-descriptor.md
@@ -63,6 +63,9 @@ The schema is as follows:
       - **`value`** _(string, optional, default: latest)_\
         The assigned version of the environment variable
 
+   - **`builder`** _(string, optional)_\
+    The builder image to use for the build.
+
    - **`include`** _(string list, optional)_\
     A list of files to include in the build, while excluding everything else.
 


### PR DESCRIPTION
I found some [Google Cloud docs about this](https://cloud.google.com/docs/buildpacks/use-a-specific-builder), but they seem to be non-standard. This change adds a section explaining the standard way to set the builder.