### PR TITLE
Update specify-launch-process docs

### DIFF
--- a/content/docs/for-app-developers/how-to/build-outputs/specify-launch-process.md
+++ b/content/docs/for-app-developers/how-to/build-outputs/specify-launch-process.md
@@ -54,7 +54,7 @@ Rebasable: true
 
 Buildpacks:
   ID                             VERSION           HOMEPAGE
-  samples/java-maven             0.0.1             https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven
+  samples/java-maven             0.0.2             https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven
   samples/hello-processes        0.0.1             https://github.com/buildpacks/samples/tree/main/buildpacks/hello-process
 
 Processes:
@@ -63,7 +63,7 @@ Processes:
   sys-info             bash         /layers/samples_hello-processes/sys-info/sys-info.sh
 ```
 
-Notice that the default process type is `web`. This is because `pack` will always attempt to set the default process type to `web` unless the `--default-process` flag is passed.
+Notice that the `java-maven` buildpack defined `web` as the default process type.
 If we had run the `pack build` command above with `--default-process sys-info`, `sys-info` would be the default process for the app image!
 
 ### Run a multi-process app


### PR DESCRIPTION
Remove mention of `pack` always treating `web` as the default process type. The `java-maven` buildpack [was updated](https://github.com/buildpacks/samples/commit/8fa4447e65145e5a727d203103c554bce2b085d6) to explicitly set the default process type (after the buildpack API version was bumped from 0.2 to 0.9, and [`pack` only sets the `web` process as default for < 0.6](https://github.com/buildpacks/spec/blob/main/platform.md#outputs-4)).

Also, the java-maven sample buildpack version is now [0.0.2](https://github.com/buildpacks/samples/commit/09460d909bc9f793e173e384f7396d4adbb07f3c).