### PR TITLE
Update existing lifecycle phases (Platform)

### DIFF
--- a/content/docs/for-platform-operators/concepts/lifecycle/_index.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/_index.md
@@ -17,21 +17,21 @@ An **image build** requires 5 lifecycle phases, as shown below:
 
 > **Note**: when talking about lifecycle phases you'll sometimes see nouns like `analyzer` or `/cnb/lifecycle/analyzer`
 > and you'll sometimes see verbs like `analyze` or `analyze phase`.<br><br>
-> These are all more-or-less interchangeable: the nouns refer to the lifecycle binary and the verbs refer to the work that the lifecycle performs.
+> These are all more-or-less interchangeable: the nouns refer to the `lifecycle` binary and the verbs refer to the work that the `lifecycle` performs.
 
-The lifecycle must be run in a containerized environment (such as a Docker container or CI/CD system).
+The `lifecycle` must be run in a containerized environment (such as a `Docker` container or `CI/CD` system).
 
 The [`analyzer`][analyzer], [`restorer`][restorer], and [`exporter`][exporter] (shown in pink above)
-require access to an image repository - either an **OCI registry** or Docker-compliant **daemon** (such as Docker or Podman)
+require access to an image repository - either an **OCI registry** or Docker-compliant **daemon** (such as `Docker` or `Podman`)
 in order to do their work.
 
-This means that either registry credentials or a Docker socket must be available in the container where the lifecycle phase is running.
+This means that either registry credentials or a `Docker` socket must be available in the container where the lifecycle phase is running.
 For security hardening, these phases run in separate containers to avoid exposing sensitive data to **buildpacks**.
 
 The [`detector`][detector] and [`builder`][builder] (shown in purple above)
 invoke buildpacks to do the work of determining which buildpacks are needed and
 transforming application source code into runnable artifacts (the real work of buildpacks!).
-For security hardening, both the lifecycle and buildpacks run as non-root users when doing this work.
+For security hardening, both the `lifecycle` and buildpacks run as non-root users when doing this work.
 
 When a builder is [trusted][trusted builder], all 5 lifecycle phases can be run in the same container,
 and in this case the [`creator`][creator] binary is used to run all 5 lifecycle phases with a single command invocation.

--- a/content/docs/for-platform-operators/concepts/lifecycle/analyze.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/analyze.md
@@ -12,10 +12,19 @@ The `analyzer` restores files that buildpacks may use to optimize the `build` an
 
 Prior to `Platform API 0.7`, the `analyzer` was responsible for analyzing the metadata from the cache and the previously built image, if available, to determine what layers can or cannot be reused.
 This information is used during the `export` phase in order to avoid re-uploading unchanged layers.\
-Starting from `Platform API 0.7`, the `analyze` phase runs before the `detect` phase in order to validate registry access for all images that are used during the build as early as possible. In this way it provides faster failures for end users. The other responsibilities of the `analyzer` were moved to the `restorer`.\
+Starting from `Platform API 0.7`, the `analyze` phase runs before the `detect` phase in order to validate registry access for all images that are used during the `build` as early as possible. In this way it provides faster failures for end users. The other responsibilities of the `analyzer` were moved to the `restorer`.\
 For more information, please see [this migration guide][platform-api-06-07-migration].
 
+The `lifecycle` should attempt to locate a reference to the latest `OCI image` from a previous build that is readable and was created by the `lifecycle` using the same application source code. If no such reference is found, the `analysis` is skipped.\
+
+The `lifecycle` must write [analysis metadata][analyzedtoml-toml] to `<analyzed>`, where:
+
+- `image` MUST describe the `<previous-image>`, if accessible
+- `run-image` MUST describe the `<run-image>`
+
 ### Exit Codes
+
+If the `analyze` phase was successful or there was any error during the process, the output will have one of the following exit codes:
 
 | Exit Code       | Result                              |
 |-----------------|-------------------------------------|
@@ -25,4 +34,9 @@ For more information, please see [this migration guide][platform-api-06-07-migra
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `30-39`         | Analysis-specific lifecycle errors  |
 
+***
+
+For more information about the `analyzer`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#analyzer).
+
 [platform-api-06-07-migration]: https://buildpacks.io/docs/for-platform-operators/how-to/migrate/deprecated/platform-api-0.6-0.7/
+[analyzedtoml-toml]: https://github.com/buildpacks/spec/blob/main/platform.md#analyzedtoml-toml

--- a/content/docs/for-platform-operators/concepts/lifecycle/analyze.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/analyze.md
@@ -1,4 +1,3 @@
-
 +++
 title="Analyze"
 aliases=[
@@ -7,11 +6,11 @@ aliases=[
 weight=1
 +++
 
-The `analyzer` restores files that buildpacks may use to optimize the build and export phases.
+The `analyzer` restores files that buildpacks may use to optimize the `build` and `export` phases.
 
 <!--more-->
 
-Prior to `Platform API 0.7`, the `analyzer` was responsible for analyzing the metadata from the cache and the previously built image (if available) to determine what layers can or cannot be reused.
+Prior to `Platform API 0.7`, the `analyzer` was responsible for analyzing the metadata from the cache and the previously built image, if available, to determine what layers can or cannot be reused.
 This information is used during the `export` phase in order to avoid re-uploading unchanged layers.\
 Starting from `Platform API 0.7`, the `analyze` phase runs before the `detect` phase in order to validate registry access for all images that are used during the build as early as possible. In this way it provides faster failures for end users. The other responsibilities of the `analyzer` were moved to the `restorer`.\
 For more information, please see [this migration guide][platform-api-06-07-migration].
@@ -26,4 +25,4 @@ For more information, please see [this migration guide][platform-api-06-07-migra
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `30-39`         | Analysis-specific lifecycle errors  |
 
-[platform-api-06-07-migration]: https://buildpacks.io/docs/for-platform-operators/how-to/migrate/platform-api-0.6-0.7/
+[platform-api-06-07-migration]: https://buildpacks.io/docs/for-platform-operators/how-to/migrate/deprecated/platform-api-0.6-0.7/

--- a/content/docs/for-platform-operators/concepts/lifecycle/build.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/build.md
@@ -7,6 +7,8 @@ The `builder` transforms application source code into runnable artifacts that ca
 
 <!--more-->
 
+The `platform` must execute `builder` in the `build` environment.
+
 ### Exit Codes
 
 | Exit Code       | Result                              |
@@ -17,3 +19,7 @@ The `builder` transforms application source code into runnable artifacts that ca
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `51`            | Buildpack build error               |
 | `50`, `52-59`   | Build-specific lifecycle errors     |
+
+***
+
+For more information about the `builder`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#builder).

--- a/content/docs/for-platform-operators/concepts/lifecycle/create.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/create.md
@@ -3,11 +3,15 @@ title="Create"
 weight=6
 +++
 
-The `creator` runs analyze, detect, restore, build, and export in a single command.
+The `creator` runs `analyze`, `detect`, `restore`, `build`, and `export` in a single command.
 
 <!--more-->
 
+The `platform` must execute `creator` in the `build` environment.
+
 ### Exit Codes
+
+The outputs produced by `creator` are identical to those produced by `exporter`, with the following additional expanded set of error codes.
 
 | Exit Code       | Result                                |
 |-----------------|---------------------------------------|
@@ -20,3 +24,7 @@ The `creator` runs analyze, detect, restore, build, and export in a single comma
 | `40-49`         | Restoration-specific lifecycle errors |
 | `50-59`         | Build-specific lifecycle errors       |
 | `60-69`         | Export-specific lifecycle errors      |
+
+***
+
+For more information about the `creator`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#creator).

--- a/content/docs/for-platform-operators/concepts/lifecycle/create.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/create.md
@@ -8,6 +8,10 @@ The `creator` runs `analyze`, `detect`, `restore`, `build`, and `export` in a si
 <!--more-->
 
 The `platform` must execute `creator` in the `build` environment.
+An image reference (i.e., `<previous-image>`) to be analyzed is one of the `creator`'s inputs.  
+
+- **If** `<skip-restore>` is `true` the `creator` shall skip the restoration of any data to each buildpack's layers directory, with the exception of `store.toml`.
+- **If** the platform provides one or more `<tag>` inputs they shall be treated as additional `<image>` inputs to the `exporter`
 
 ### Exit Codes
 

--- a/content/docs/for-platform-operators/concepts/lifecycle/detect.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/detect.md
@@ -1,4 +1,3 @@
-
 +++
 title="Detect"
 aliases=[
@@ -7,7 +6,7 @@ aliases=[
 weight=2
 +++
 
-The `detector` finds an ordered group of buildpacks to use during the build phase.
+The `detector` finds an ordered group of buildpacks to use during the `build` phase.
 
 <!--more-->
 
@@ -17,6 +16,7 @@ The detector is invoked in the build environment without any required arguments 
 One of the [input files][inputs] is [`order.toml`][order] and two of its [output files][outputs] are [`group.toml`][group] and [`plan.toml`][plan].
 
 Unless some flags are passed in, the detector will use the following defaults:
+
 * Path resolution for order definition: `/cnb/order.toml`
 * Path to output group definition: `<layers>/group.toml`
 * Path to output resolved build plan: `<layers>/plan.toml`
@@ -31,6 +31,7 @@ If all of the groups fail, the detection process fails.
 
 Each buildpack in each group is marked as either optional or as required.
 In order to pass the detection process, two conditions must be satisfied:
+
 * The detect scripts of all required buildpacks must pass successfully (the exit code is zero).
 * The detector should be able to create a build plan (to be written in the `plan.toml`) with all of the requirements of the group’s buildpacks.
 
@@ -48,6 +49,7 @@ Each buildpack can define two lists with provided and required dependencies (or 
 The detector reads the build plans of the buildpacks of the “chosen” group (after filtering out the buildpacks whose detect script failed). It goes over all of the options and tries to create a file with a list of entries, each with provides and requires lists, that fulfills all of the buildpacks requirements. Each of the options is called a trial, and this output file is called `plan.toml`.
 
 The two restrictions for provides and requires are:
+
 * A dependency that is provided by a buildpack, must be required by either the buildpack itself or by a later buildpack in the group.
 * A dependency that is required by a buildpack, must be provided by the buildpack itself or by a previous buildpack in the group.
 
@@ -57,19 +59,19 @@ If at least one of the above failed on a required buildpack, the trial fails and
 
 | Exit Code       | Result|
 |-----------------|-------|
-| `0`             | Success
-| `11`            | Platform API incompatibility error
-| `12`            | Buildpack API incompatibility error
-| `1-10`, `13-19` | Generic lifecycle errors
-| `20`            | All buildpacks groups have failed to detect w/o error
-| `21`            | All buildpack groups have failed to detect and at least one buildpack has errored
-| `22-29`         | Detection-specific lifecycle errors
+| `0`             | Success|
+| `11`            | Platform API incompatibility error|
+| `12`            | Buildpack API incompatibility error|
+| `1-10`, `13-19` | Generic lifecycle errors|
+| `20`            | All buildpacks groups have failed to detect w/o error|
+| `21`            | All buildpack groups have failed to detect and at least one buildpack has errored|
+| `22-29`         | Detection-specific lifecycle errors|
 
-### Some links to important parts of the code:
+### Some links to important parts of the code
 
-The following file is responsible for the detection command: https://github.com/buildpacks/lifecycle/blob/main/cmd/lifecycle/detector.go. 
+The following file is responsible for the detection command: <https://github.com/buildpacks/lifecycle/blob/main/cmd/lifecycle/detector.go>.
 
-The public functions in the above file are being called by the `Run` function in the following file: https://github.com/buildpacks/lifecycle/blob/main/cmd/command.go
+The public functions in the above file are being called by the `Run` function in the following file: <https://github.com/buildpacks/lifecycle/blob/main/cmd/lifecycle/cli/command.go>
 
 The spec of the detector can be found [here][spec].
 

--- a/content/docs/for-platform-operators/concepts/lifecycle/detect.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/detect.md
@@ -10,12 +10,12 @@ The `detector` finds an ordered group of buildpacks to use during the `build` ph
 
 <!--more-->
 
-Detection is the first phase of the Lifecycle. It’s done by the `detector`.
-In this phase, the detector looks for an ordered group of buildpacks that will be used during the build phase.
-The detector is invoked in the build environment without any required arguments and it cannot run with root privileges.
+Detection is the first phase of the `Lifecycle`. It’s done by the `detector`.
+In this phase, the `detector` looks for an ordered group of buildpacks that will be used during the `build` phase.
+The `detector` is invoked in the `build` environment without any required arguments and it cannot run with root privileges.
 One of the [input files][inputs] is [`order.toml`][order] and two of its [output files][outputs] are [`group.toml`][group] and [`plan.toml`][plan].
 
-Unless some flags are passed in, the detector will use the following defaults:
+Unless some flags are passed in, the `detector` will use the following defaults:
 
 * Path resolution for order definition: `/cnb/order.toml`
 * Path to output group definition: `<layers>/group.toml`
@@ -33,9 +33,9 @@ Each buildpack in each group is marked as either optional or as required.
 In order to pass the detection process, two conditions must be satisfied:
 
 * The detect scripts of all required buildpacks must pass successfully (the exit code is zero).
-* The detector should be able to create a build plan (to be written in the `plan.toml`) with all of the requirements of the group’s buildpacks.
+* The detector should be able to create a `build plan` (to be written in the `plan.toml`) with all of the requirements of the group’s buildpacks.
 
-The first group that passes both steps is written to `group.toml` and its build plan is written to `plan.toml`.
+The first group that passes both steps is written to `group.toml` and its `build plan` is written to `plan.toml`.
 
 Note: If the detect script of an optional buildpack failed, the group can still pass the detection process and be the “chosen”  group. In order for that to happen, there should be at least one (required or optional) buildpack in this group that passes the detect script successfully.
 
@@ -46,7 +46,7 @@ The buildpacks of the “chosen” group will be written to `group.toml` if they
 ### `plan.toml`
 
 Each buildpack can define two lists with provided and required dependencies (or several pairs of lists separated by `or`). These lists (if they aren’t empty) are called a [build plan][buildPlan] and they are part of the [output of each buildpack’s detect script][detectScriptOutput].
-The detector reads the build plans of the buildpacks of the “chosen” group (after filtering out the buildpacks whose detect script failed). It goes over all of the options and tries to create a file with a list of entries, each with provides and requires lists, that fulfills all of the buildpacks requirements. Each of the options is called a trial, and this output file is called `plan.toml`.
+The `detector` reads the build plans of the buildpacks of the “chosen” group (after filtering out the buildpacks whose detect script failed). It goes over all of the options and tries to create a file with a list of entries, each with provides and requires lists, that fulfills all of the buildpacks requirements. Each of the options is called a trial, and this output file is called `plan.toml`.
 
 The two restrictions for provides and requires are:
 

--- a/content/docs/for-platform-operators/concepts/lifecycle/export.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/export.md
@@ -6,7 +6,7 @@ aliases=[
 weight=5
 +++
 
-The `exporter` creates the final OCI image.
+The `exporter` creates the final `OCI image` and updates the image config with new metadata to reflect the latest changes.
 
 <!--more-->
 
@@ -22,11 +22,16 @@ The `exporter` creates the final OCI image.
 
 ### Image
 
-The `exporter` accepts as an argument the tag reference to which the app image will be written, either in an OCI image registry or a docker daemon.
+The `exporter` accepts as an argument the `<image>` tag reference to which the app image will be written, either in an `OCI image` registry or a `docker daemon`.
+
+* At least one `<image>` must be provided.
+* Each `<image>` must be a valid tag reference.  
+* If `<daemon>` is false and more than one `<image>` is provided they must refer to the same registry.  
+* The `<run-image>` will be read from `analyzed.toml`.
 
 ### report.toml
 
-The `exporter` will write a [`report.toml`](https://github.com/buildpacks/spec/blob/main/platform.md#reporttoml-toml) containing information about the exported image such as its digest and manifest size (if exported to an OCI registry) or identifier, and any build BOM contributed by buildpacks. The location of the output report can be specified by passing the `-report` flag; by default, it is written to `<layers>/report.toml` - note that this is NOT present in the filesystem of the exported image.
+The `exporter` will write a [`report.toml`](https://github.com/buildpacks/spec/blob/main/platform.md#reporttoml-toml) containing information about the exported image such as its digest and manifest size (if exported to an `OCI registry`) or identifier, and any build BOM contributed by buildpacks. The location of the output report can be specified by passing the `-report` flag; by default, it is written to `<layers>/report.toml` - note that this is NOT present in the filesystem of the exported image.
 
 ***
 

--- a/content/docs/for-platform-operators/concepts/lifecycle/export.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/export.md
@@ -1,4 +1,3 @@
-
 +++
 title="Export"
 aliases=[

--- a/content/docs/for-platform-operators/concepts/lifecycle/extend.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/extend.md
@@ -3,7 +3,7 @@ title="Extend"
 weight=9
 +++
 
-The `extender` applies Dockerfiles output by image extensions to the build or runtime base image.
+The `extender` applies Dockerfiles output by image extensions to the `build` or `runtime` base image.
 
 <!--more-->
 
@@ -16,3 +16,7 @@ The `extender` applies Dockerfiles output by image extensions to the build or ru
 | `12`            | Buildpack API incompatibility error |
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `100-109`       | Extension-specific lifecycle errors |
+
+***
+
+For more information about the `extender`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#extender-optional).

--- a/content/docs/for-platform-operators/concepts/lifecycle/extend.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/extend.md
@@ -3,11 +3,16 @@ title="Extend"
 weight=9
 +++
 
-The `extender` applies Dockerfiles output by image extensions to the `build` or `runtime` base image.
+The `extender` applies `Dockerfiles` output by image extensions to the `build` or `runtime` base image.
 
 <!--more-->
 
 ### Exit Codes
+
+When extending the build image:
+
+- In addition to the outputs enumerated below, outputs produced by `extender` include those produced by `builder` - as the `lifecycle` will run the `build` phase after extending the `build image`.
+- Platforms MUST skip the `builder` and proceed to the `exporter`.
 
 | Exit Code       | Result                              |
 |-----------------|-------------------------------------|
@@ -16,6 +21,21 @@ The `extender` applies Dockerfiles output by image extensions to the `build` or 
 | `12`            | Buildpack API incompatibility error |
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `100-109`       | Extension-specific lifecycle errors |
+
+- For each extension in `<group>` in order, if a `Dockerfile` exists in `<generated>/<buildpack-id>/<kind>.Dockerfile`, the `lifecycle`:
+  - Shall apply the `Dockerfile` to the environment according to the process outlined in the [Image Extension Specification](https://github.com/buildpacks/spec/blob/main/image_extension.md).
+  - SHALL set the build context to the folder according to the process outlined in the [Image Extension Specification](https://github.com/buildpacks/spec/blob/main/image_extension.md).
+- The extended image must be an extension of:
+  - The `build-image` in `<analyzed>` when `<kind>` is `build`, or
+  - The `run-image` in `<analyzed>` when `<kind>` is `run`
+- When extending the `build image`, after all `build.Dockerfile`s are applied, the `lifecycle`:
+  - Shall proceed with the `build` phase using the provided `<gid>` and `<uid>`
+- When extending the run image, after all `run.Dockerfile`s are applied, the `lifecycle`:
+  - **If** any `run.Dockerfile` set the label `io.buildpacks.rebasable` to `false` or left the label unset:
+    - Shall set the label `io.buildpacks.rebasable` to `false` on the extended run image
+  - **If** after the final `run.Dockerfile` the run image user is `root`,
+    - Shall fail
+  - Shall copy the manifest and config for the extended run image, along with any new layers, to `<extended>`/run
 
 ***
 

--- a/content/docs/for-platform-operators/concepts/lifecycle/launch.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/launch.md
@@ -9,8 +9,16 @@ The `launcher` is the entrypoint for the final OCI image, responsible for launch
 
 ### Exit Codes
 
+If the `launcher` errors before executing the process, it will have one of the following error codes:
+
 | Exit Code | Result                              |
 |-----------|-------------------------------------|
 | `11`      | Platform API incompatibility error  |
 | `12`      | Buildpack API incompatibility error |
 | `80-89`   | Launch-specific lifecycle errors    |
+
+Otherwise, the exit code shall be the exit code of the launched process.
+
+***
+
+For more information about the `launcher`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#launcher).

--- a/content/docs/for-platform-operators/concepts/lifecycle/rebase.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/rebase.md
@@ -3,7 +3,7 @@ title="Rebase"
 weight=8
 +++
 
-The `rebaser` places application layers atop a new version of the runtime base image.
+The `rebaser` places application layers atop a new version of the `runtime` base image.
 
 <!--more-->
 
@@ -16,3 +16,7 @@ The `rebaser` places application layers atop a new version of the runtime base i
 | `12`            | Buildpack API incompatibility error |
 | `1-10`, `13-19` | Generic lifecycle errors            |
 | `70-79`         | Rebase-specific lifecycle errors    |
+
+***
+
+For more information about the `rebaser`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#rebaser).

--- a/content/docs/for-platform-operators/concepts/lifecycle/restore.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/restore.md
@@ -16,3 +16,7 @@ The `restorer` copies layers from the cache into the build container.
 | `12`            | Buildpack API incompatibility error   |
 | `1-10`, `13-19` | Generic lifecycle errors              |
 | `40-49`         | Restoration-specific lifecycle errors |
+
+***
+
+For more information about the `restorer`, see the [Platform API spec](https://github.com/buildpacks/spec/blob/main/platform.md#restorer).

--- a/content/docs/for-platform-operators/concepts/lifecycle/restore.md
+++ b/content/docs/for-platform-operators/concepts/lifecycle/restore.md
@@ -3,11 +3,35 @@ title="Restore"
 weight=3
 +++
 
-The `restorer` copies layers from the cache into the build container.
+The `restorer` copies layers from the `cache` into the `build` container.
 
 <!--more-->
 
+During this phase, the `restorer` looks for layers that could be reused or should be replaced while building the app image.
+
+One of the `restorer`'s [input files](https://github.com/buildpacks/spec/blob/main/platform.md#inputs-2) are `<cache-dir>`and `<cache-image>`to retrieve cache contents, and two of its [output files](https://github.com/buildpacks/spec/blob/main/platform.md#outputs-2) are `store.toml` and `<layer>.toml`.
+
+Unless the `<skip-layers>` flag is passed in as `true`, the `restorer` must always perform [layer restoration](#layer-restoration)
+
+- For each buildpack in `<group>`, if persistent metadata for that buildpack exists in the analysis metadata, the `lifecycle` must write a `toml` representation of the persistent metadata to `<layers>/<buildpack-id>/store.toml`
+- **If** `<skip-layers>` is `true` the lifecycle must not perform layer restoration.
+- **Else** the `lifecycle` must perform [layer restoration](#layer-restoration) for any app image layers or cached layers created by any buildpack present in the provided `<group>`.
+- When `<build-image>` is provided (optional), the lifecycle:
+  - MUST record the digest reference to the provided `<build-image>` in `<analyzed>`
+  - MUST copy the OCI manifest and config file for `<build-image>` to `<kaniko-dir>/cache`
+- The `lifecycle`:
+  - Must [resolve mirrors](https://github.com/buildpacks/spec/blob/main/platform.md#run-image-resolution) for the `run-image.reference` in `<analyzed>` and resolve it to a digest reference
+  - Must populate `run-image.target` data in `<analyzed>` if not present
+  - **If** `<analyzed>` has `run-image.extend = true`, the `lifecycle`:
+    - Must download from the registry and save in OCI layout format the `run-image` in `<analyzed>` to `<kaniko-dir>/cache`
+
+### Layer Restoration
+
+The `lifecycle` must use the provided `cache-dir` or `cache-image` to retrieve cache contents. The [rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-types) for restoration must be followed when determining how and when to store cache layers.
+
 ### Exit Codes
+
+If the `restore` phase was successful or there was any error during the process, the output will have one of the following exit codes:
 
 | Exit Code       | Result                                |
 |-----------------|---------------------------------------|


### PR DESCRIPTION
Expand Platform lifecycle/phases pages

- Adds some content related to the platform lifecycle/phases section
- Adds links to the specs
- Minor MD styling of current content
- Update broken links 

closes #766 