### PR TITLE
Update build-for-arm.md

### DIFF
--- a/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
+++ b/content/docs/for-app-developers/how-to/special-cases/build-for-arm.md
@@ -10,7 +10,7 @@ weight=1
 <!--more-->
 
 Building for the ARM architecture is now easier than ever! The `heroku/builder:24` builder supports both AMD64 and ARM64 architectures, and includes
-multi-arch Go, Java, Node.js, PHP, Python, Ruby and Scala buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
+multi-arch .NET, Go, Java, Node.js, PHP, Python, Ruby and Scala buildpacks. You can read more about Heroku's [Cloud Native Buildpacks here][heroku-buildpacks].
 
 > **NOTE:** Our current multi-architecture support allows building an ARM64 application image on an ARM64 host, and building an AMD64 application image on an AMD64 host. We do not currently support building an application image for one architecture on a different architecture. However, if your host machine supports emulation (e.g., with QEMU) you may be able to perform cross platform builds, albeit with a performance penalty.
 


### PR DESCRIPTION
Add .NET to list of multi-arch buildpacks supported by `heroku/builder:24`