### PR TITLE
Chore: Upgrade jQuery and Axios version

### DIFF
--- a/content/docs/for-buildpack-authors/concepts/buildpack-group.md
+++ b/content/docs/for-buildpack-authors/concepts/buildpack-group.md
@@ -53,7 +53,6 @@ After the buildpack groups are expanded they are processed in the same way and h
 
 The [Operator's Guide][operator-guide] has more information on creating builders and defining order groups in builders.
 
-[buildpack-group]: /docs/reference/config/builder-config/#order-_list-required_
 [order-resolution]: https://github.com/buildpacks/spec/blob/main/buildpack.md#order-resolution
 [operator-guide]: /docs/for-platform-operators/
 [builder]: /docs/for-platform-operators/concepts/builder/

--- a/themes/buildpacks/layouts/_default/baseof.html
+++ b/themes/buildpacks/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
   {{ partial "meta.html" . }}
 
   <script
-    src="https://cdn.jsdelivr.net/combine/npm/axios@0.21.0,npm/jquery@3.5.1,npm/bootstrap@5.3.3,npm/fullcalendar@5.4.0,npm/jquery-replacetext@1.1.0/replacetext.min.js"></script>
+    src="https://cdn.jsdelivr.net/combine/npm/axios@1.7.9,npm/jquery@3.7.1,npm/bootstrap@4.5.3,npm/fullcalendar@5.4.0,npm/jquery-replacetext@1.1.0/replacetext.min.js"></script>
 
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.1/css/all.min.css"

--- a/themes/buildpacks/layouts/_default/baseof.html
+++ b/themes/buildpacks/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
   {{ partial "meta.html" . }}
 
   <script
-    src="https://cdn.jsdelivr.net/combine/npm/axios@1.7.9,npm/jquery@3.7.1,npm/bootstrap@4.5.3,npm/fullcalendar@5.4.0,npm/jquery-replacetext@1.1.0/replacetext.min.js"></script>
+    src="https://cdn.jsdelivr.net/combine/npm/axios@1.7.9,npm/jquery@3.7.1,npm/bootstrap@5.3.3,npm/fullcalendar@5.4.0,npm/jquery-replacetext@1.1.0/replacetext.min.js"></script>
 
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.1/css/all.min.css"


### PR DESCRIPTION
## Summary 
Upgraded jQuery version to latest(3.7.1) and Axios to 1.7.9

## Before 
<img width="1709" alt="Screenshot 2025-02-20 at 10 04 45" src="https://github.com/user-attachments/assets/0be7ff45-8b23-4442-9761-07c7671717d9" />

## After
<img width="1709" alt="Screenshot 2025-02-20 at 10 03 49" src="https://github.com/user-attachments/assets/37145668-b74b-433f-a267-4ea60836edb5" />
