### PR TITLE
Fix documentation on project.toml env vars

### DIFF
--- a/content/docs/for-app-developers/how-to/build-inputs/configure-build-time-environment.md
+++ b/content/docs/for-app-developers/how-to/build-inputs/configure-build-time-environment.md
@@ -115,7 +115,7 @@ You can define environment variables in an `env` table in the file, and pass tho
 ```
 cat >> samples/apps/bash-script/project.toml <<EOL
 
-[[build.env]]
+[[io.buildpacks.build.env]]
 name="HELLO"
 value="WORLD"
 EOL


### PR DESCRIPTION
In [Use project.toml](https://buildpacks.io/docs/for-app-developers/how-to/build-inputs/use-project-toml/) it is suggested to add env vars under [[io.buildpacks.build.env]] and not under [[build.env]], which seems incorrect.