### PR TITLE
Fix `launch.toml` in use-inline-buildpacks.md

### DIFF
--- a/content/docs/for-app-developers/how-to/build-inputs/use-inline-buildpacks.md
+++ b/content/docs/for-app-developers/how-to/build-inputs/use-inline-buildpacks.md
@@ -50,7 +50,7 @@ find . -type f -name $(my_data_files) -delete
 cat <<EOF > ${1}/launch.toml
 [[processes]]
 type = 'bash'
-command = 'bin/bash'
+command = ['bin/bash']
 EOF
 """
 ```


### PR DESCRIPTION
The `launch.toml` command takes a slice and not a string

```
remote: ERROR: failed to build: toml: line 3 (last key "processes.command"): incompatible types: TOML value has type string; destination has type slice
```

Spec: https://github.com/buildpacks/spec/blob/d29ba81518b7304700e9e8a54cc2194fa732e51b/buildpack.md#launchtoml-toml